### PR TITLE
New option `native_numbers` to use underlying C library numbers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -56,13 +56,15 @@
                            DATETIME_MODE_ISO8601_IGNORE_TZ, DATETIME_MODE_ISO8601_UTC,
                            UUID_MODE_NONE, UUID_MODE_CANONICAL, UUID_MODE_HEX)
 
-.. function:: dumps(obj, skipkeys=False, ensure_ascii=True, allow_nan=True, indent=None, \
+.. function:: dumps(obj, skipkeys=False, ensure_ascii=True, allow_nan=True, \
+                    native_numbers=False, indent=None, \
                     default=None, sort_keys=False, use_decimal=False, \
                     max_recursion_depth=2048, datetime_mode=None, uuid_mode=None)
 
    :param bool skipkeys: whether skip invalid :class:`dict` keys
    :param bool ensure_ascii: whether the output should contain only ASCII characters
    :param bool allow_nan: whether ``NaN`` values are handled or not
+   :param bool native_numbers: whether use arch's native numbers or not
    :param int indent: indentation width to produce pretty printed JSON
    :param callable default: a function that gets called for objects that can't otherwise be
                             serialized
@@ -116,6 +118,19 @@
        Traceback (most recent call last):
          File "<stdin>", line 1, in <module>
        ValueError: Out of range float values are not JSON compliant
+
+   If `native_numbers` is true (default: ``False``), then the numeric values (i.e. *floats* and
+   *integers*) will be handled using architecture *native* arithmetic: while this is somewhat
+   faster, it is subject to the underlying C library ``long long`` and ``double`` limits:
+
+   .. doctest::
+
+      >>> dumps(123456789012345678901234567890)
+      '123456789012345678901234567890'
+      >>> dumps(123456789012345678901234567890, native_numbers=True)
+      Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+      OverflowError: int too big to convert
 
    When `indent` is ``None`` (the default), ``python-rapidjson`` produces the most compact JSON
    representation. By setting `indent` to 0 each array item and each dictionary value will be
@@ -267,7 +282,7 @@
        '"be57634565b54fc292c594e2f82e38fd"'
 
 .. function:: loads(s, object_hook=None, use_decimal=False, allow_nan=True, \
-                    datetime_mode=None, uuid_mode=None)
+                    native_numbers=False, datetime_mode=None, uuid_mode=None)
 
    :param str s: The JSON string to parse
    :param callable object_hook: an optional function that will be called with the result of
@@ -275,6 +290,7 @@
                                 the value to use instead of the :class:`dict`
    :param bool use_decimal: whether :class:`Decimal` should be used for float values
    :param bool allow_nan: whether ``NaN`` values are recognized
+   :param bool native_numbers: whether use arch's native numbers or not
    :param int datetime_mode: how should :class:`datetime` and :class:`date` instances be
                              handled
    :param int uuid_mode: how should :class:`UUID` instances be handled
@@ -323,6 +339,18 @@
        Traceback (most recent call last):
          File "<stdin>", line 1, in <module>
        ValueError: … Out of range float values are not JSON compliant
+
+   If `native_numbers` is true (default: ``False``), then the numeric values (i.e. *floats* and
+   *integers*) will be handled using architecture *native* arithmetic: while this is quite
+   faster, integers that do not fit into the underlying C library ``long long`` limits will be
+   converted (*truncated*) to ``double`` numbers:
+
+   .. doctest::
+
+      >>> loads('123456789012345678901234567890')
+      123456789012345678901234567890
+      >>> loads('123456789012345678901234567890', native_numbers=True)
+      1.2345678901234566e+29
 
    With `datetime_mode` you can enable recognition of string literals containing an `ISO 8601`_
    representation as either :class:`date` or :class:`datetime` instances:

--- a/python-rapidjson/docstrings.h
+++ b/python-rapidjson/docstrings.h
@@ -5,14 +5,15 @@ PyDoc_STRVAR(rapidjson_module_docstring,
              "Fast, simple JSON encoder and decoder. Based on RapidJSON C++ library.");
 
 PyDoc_STRVAR(rapidjson_loads_docstring,
-             "loads(s, object_hook=None, use_decimal=False,"
-             " allow_nan=True, datetime_mode=None, uuid_mode=None)\n"
+             "loads(s, object_hook=None, use_decimal=False, allow_nan=True,"
+             " native_numbers=False, datetime_mode=None, uuid_mode=None)\n"
              "\n"
              "Decodes a JSON string into Python object.");
 
 PyDoc_STRVAR(rapidjson_dumps_docstring,
-             "dumps(obj, skipkeys=False, ensure_ascii=True, allow_nan=True, indent=None,"
-             " default=None, sort_keys=False, use_decimal=False, max_recursion_depth=2048,"
+             "dumps(obj, skipkeys=False, ensure_ascii=True, allow_nan=True,"
+             " native_numbers=False, indent=None, default=None, sort_keys=False,"
+             " use_decimal=False, max_recursion_depth=2048,"
              " datetime_mode=None, uuid_mode=None)\n"
              "\n"
              "Encodes Python object into a JSON string.");

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,13 @@ contenders.append(Contender('rapidjson',
                             rapidjson.dumps,
                             rapidjson.loads))
 
+numbers_contenders = [
+    Contender('Wide numbers', rapidjson.dumps, rapidjson.loads),
+    Contender('Native numbers',
+              partial(rapidjson.dumps, native_numbers=True),
+              partial(rapidjson.loads, native_numbers=True))
+]
+
 try:
     import yajl
 except ImportError:
@@ -79,3 +86,6 @@ def pytest_generate_tests(metafunc):
                               partial(rapidjson.loads,
                                       datetime_mode=rapidjson.DATETIME_MODE_ISO8601)],
                              ids=['Ignore datetimes', 'Parse datetimes'])
+
+    if 'numbers_contender' in metafunc.fixturenames:
+        metafunc.parametrize('numbers_contender', numbers_contenders, ids=attrgetter('name'))

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -32,6 +32,7 @@ user = {
 friends = [ user, user, user, user, user, user, user, user ]
 
 doubles = []
+numbers = []
 unicode_strings = []
 strings = []
 booleans = []
@@ -46,6 +47,8 @@ complex_object = [
 
 for x in range(256):
     doubles.append(sys.maxsize * random.random())
+    numbers.append(sys.maxsize * random.random())
+    numbers.append(random.randint(0, sys.maxsize))
     unicode_strings.append("نظام الحكم سلطاني وراثي في الذكور من ذرية السيد تركي بن سعيد بن سلطان ويشترط فيمن يختار لولاية الحكم من بينهم ان يكون مسلما رشيدا عاقلا ًوابنا شرعيا لابوين عمانيين ")
     strings.append("A pretty long string which is in a list")
     booleans.append(True)
@@ -90,7 +93,7 @@ def test_loads(contender, data, benchmark):
     benchmark(contender.loads, data)
 
 
-# Special case: load datetimes as plain strings vs datetime.xxx instances
+# Special case 1: load datetimes as plain strings vs datetime.xxx instances
 
 @pytest.mark.benchmark(group='deserialize')
 @pytest.mark.parametrize('data', [datetimes], ids=['256x3 datetimes'])
@@ -98,3 +101,17 @@ def test_loads_datetimes(datetimes_loads_contender, data, benchmark):
     from rapidjson import dumps, DATETIME_MODE_ISO8601
     data = dumps(data, datetime_mode=DATETIME_MODE_ISO8601)
     benchmark(datetimes_loads_contender, data)
+
+
+# Special case 2: native numbers
+
+@pytest.mark.benchmark(group='serialize')
+@pytest.mark.parametrize('data', [numbers], ids=['512 numbers array'])
+def test_dumps_numbers(numbers_contender, data, benchmark):
+    benchmark(numbers_contender.dumps, data)
+
+@pytest.mark.benchmark(group='deserialize')
+@pytest.mark.parametrize('data', [numbers], ids=['512 numbers array'])
+def test_loads_numbers(numbers_contender, data, benchmark):
+    data = numbers_contender.dumps(data)
+    benchmark(numbers_contender.loads, data)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -60,6 +60,16 @@ def test_allow_nan():
 
 
 @pytest.mark.unit
+def test_native_numbers():
+    f = [-1, 1, 1.1, -2.2]
+    expected = '[-1,1,1.1,-2.2]'
+    assert rapidjson.dumps(f, native_numbers=True) == expected
+    assert rapidjson.dumps(f, native_numbers=False) == expected
+    assert rapidjson.loads(expected, native_numbers=True) == f
+    assert rapidjson.loads(expected, native_numbers=False) == f
+
+
+@pytest.mark.unit
 def test_indent():
     o = {"a": 1, "z": 2, "b": 3}
     expected1 = '{\n    "a": 1,\n    "z": 2,\n    "b": 3\n}'


### PR DESCRIPTION
This reintroduces the ability to use _native_ numbers instead of _boxed_ Python objects when dealing with load/dump of floats/ints. There is a sensible speed gain in doing so, but on the other hand native numbers are limited by the the underlying architecture while boxed _ints_ are unlimited.