### PR TITLE
Fix issue #61

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,24 @@
 Changes
 -------
 
+next (unreleased)
+~~~~~~~~~~~~~~~~~
+
+* **Backward incompatibilities**:
+
+  - all ``DATETIME_MODE_XXX`` constants have been shortened to ``DM_XXX``
+  - ``DATETIME_MODE_ISO8601_UTC`` has been renamed to ``DM_SHIFT_TO_UTC``
+
+* New option ``DM_UNIX_TIME`` to serialize date, datetime and time values as
+  `UNIX timestamps`__ targeting `issue #61`__
+
+  __ https://en.wikipedia.org/wiki/Unix_time
+  __ https://github.com/python-rapidjson/python-rapidjson/issues/61
+
+* New option ``DM_NAIVE_IS_UTC`` to treat naïve datetime and time values as if
+  they were in the UTC timezone (also for issue #61)
+
+
 0.0.11 (2017-03-05)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,19 +16,19 @@
 
    The version of the RapidJSON_ library this module is built with.
 
-.. data:: DATETIME_MODE_NONE
+.. data:: DM_NONE
 
    This is the default ``datetime_mode``: *neither* :class:`date` *nor*
    :class:`datetime` *nor* :class:`time` instances are recognized by
    :func:`dumps` and :func:`loads`.
 
-.. data:: DATETIME_MODE_ISO8601
+.. data:: DM_ISO8601
 
    In this ``datetime_mode`` mode :func:`dumps` and :func:`loads` handle
    :class:`date`, :class:`datetime` *and* :class:`date` instances representing
    those values using the `ISO 8601`_ format.
 
-.. data:: DATETIME_MODE_UNIX_TIME
+.. data:: DM_UNIX_TIME
 
    This mode tells RapidJSON to serialize :class:`date`, :class:`datetime` and
    :class:`time` as *numeric timestamps*: for the formers it is exactly the
@@ -40,27 +40,26 @@
    Since this is obviously *irreversible*, this flag is usable **only** for
    :func:`dumps`: an error is raised when passed to :func:`loads`.
 
-.. data:: DATETIME_MODE_ONLY_SECONDS
+.. data:: DM_ONLY_SECONDS
 
-   This is usable in combination with :data:`DATETIME_MODE_UNIX_TIME` so that
-   an integer representation is used, ignoring *microseconds*.
+   This is usable in combination with :data:`DM_UNIX_TIME` so that an integer
+   representation is used, ignoring *microseconds*.
 
-.. data:: DATETIME_MODE_IGNORE_TZ
+.. data:: DM_IGNORE_TZ
 
-   This can be used combined with :data:`DATETIME_MODE_ISO8601` or
-   :data:`DATETIME_MODE_UNIX_TIME`, to ignore the value's timezones.
+   This can be used combined with :data:`DM_ISO8601` or :data:`DM_UNIX_TIME`,
+   to ignore the value's timezones.
 
-.. data:: DATETIME_MODE_NAIVE_IS_UTC
+.. data:: DM_NAIVE_IS_UTC
 
-   This can be used combined with :data:`DATETIME_MODE_ISO8601` or
-   :data:`DATETIME_MODE_UNIX_TIME`, to tell RapidJSON that the naïve values
-   (that is, without an explicit timezone) are already in UTC_ timezone.
+   This can be used combined with :data:`DM_ISO8601` or :data:`DM_UNIX_TIME`,
+   to tell RapidJSON that the naïve values (that is, without an explicit
+   timezone) are already in UTC_ timezone.
 
-.. data:: DATETIME_MODE_SHIFT_TO_UTC
+.. data:: DM_SHIFT_TO_UTC
 
-   This can be used combined with :data:`DATETIME_MODE_ISO8601` or
-   :data:`DATETIME_MODE_UNIX_TIME`, to always *shift* values the UTC_
-   timezone.
+   This can be used combined with :data:`DM_ISO8601` or :data:`DM_UNIX_TIME`,
+   to always *shift* values the UTC_ timezone.
 
 .. data:: UUID_MODE_NONE
 
@@ -83,11 +82,8 @@
 
 .. testsetup::
 
-   from rapidjson import (dumps, loads,
-                          DATETIME_MODE_NONE, DATETIME_MODE_ISO8601,
-                          DATETIME_MODE_UNIX_TIME, DATETIME_MODE_ONLY_SECONDS,
-                          DATETIME_MODE_IGNORE_TZ, DATETIME_MODE_NAIVE_IS_UTC,
-                          DATETIME_MODE_SHIFT_TO_UTC,
+   from rapidjson import (dumps, loads, DM_NONE, DM_ISO8601, DM_UNIX_TIME,
+                          DM_ONLY_SECONDS, DM_IGNORE_TZ, DM_NAIVE_IS_UTC, DM_SHIFT_TO_UTC,
                           UUID_MODE_NONE, UUID_MODE_CANONICAL, UUID_MODE_HEX)
 
 .. function:: dumps(obj, skipkeys=False, ensure_ascii=True, allow_nan=True, indent=None, \
@@ -248,8 +244,8 @@
       OverflowError: Max recursion depth reached
 
    By default :class:`date`, :class:`datetime` and :class:`time` instances are
-   not serializable. When `datetime_mode` is set to :data:`DATETIME_MODE_ISO8601`
-   those values are serialized using the common `ISO 8601`_ format:
+   not serializable. When `datetime_mode` is set to :data:`DM_ISO8601` those
+   values are serialized using the common `ISO 8601`_ format:
 
    .. doctest::
 
@@ -262,82 +258,81 @@
         File "<stdin>", line 1, in <module>
       TypeError: datetime(…) is not JSON serializable
       >>> dumps(['date', date, 'time', time, 'timestamp', right_now],
-      ...       datetime_mode=DATETIME_MODE_ISO8601)
+      ...       datetime_mode=DM_ISO8601)
       '["date","2016-08-28","time","13:14:52.277256","timestamp","2016-08-28T13:14:52.277256"]'
 
    The `right_now` value is a naïve datetime (because it does not carry the
    timezone information) and is normally assumed to be in the local timezone,
    whatever your system thinks it is. When you instead *know* that your value,
    even being naïve are actually in the UTC_ timezone, you can use the
-   :data:`DATETIME_MODE_NAIVE_IS_UTC` flag to inform RapidJSON about that:
+   :data:`DM_NAIVE_IS_UTC` flag to inform RapidJSON about that:
 
    .. doctest::
 
-      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_NAIVE_IS_UTC
+      >>> mode = DM_ISO8601 | DM_NAIVE_IS_UTC
       >>> dumps(['time', time, 'timestamp', right_now], datetime_mode=mode)
       '["time","13:14:52.277256+00:00","timestamp","2016-08-28T13:14:52.277256+00:00"]'
 
-   A variant is :data:`DATETIME_MODE_SHIFT_TO_UTC`, that *shifts* all datetime
-   values to the UTC_ timezone before serializing them:
+   A variant is :data:`DM_SHIFT_TO_UTC`, that *shifts* all datetime values to
+   the UTC_ timezone before serializing them:
 
    .. doctest::
 
       >>> from datetime import timedelta, timezone
       >>> here = timezone(timedelta(hours=2))
       >>> now = datetime(2016, 8, 28, 20, 31, 11, 84418, here)
-      >>> dumps(now, datetime_mode=DATETIME_MODE_ISO8601)
+      >>> dumps(now, datetime_mode=DM_ISO8601)
       '"2016-08-28T20:31:11.084418+02:00"'
-      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_SHIFT_TO_UTC
+      >>> mode = DM_ISO8601 | DM_SHIFT_TO_UTC
       >>> dumps(now, datetime_mode=mode)
       '"2016-08-28T18:31:11.084418+00:00"'
 
-   With :data:`DATETIME_MODE_IGNORE_TZ` the timezone, if present, is simply
-   omitted:
+   With :data:`DM_IGNORE_TZ` the timezone, if present, is simply omitted:
 
    .. doctest::
 
-      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_IGNORE_TZ
+      >>> mode = DM_ISO8601 | DM_IGNORE_TZ
       >>> dumps(now, datetime_mode=mode)
       '"2016-08-28T20:31:11.084418"'
 
    Another :ref:`one-way only <no-unix-time-loads>` alternative format is
-   `Unix time`_: with :data:`DATETIME_MODE_UNIX_TIME` :class:`date`,
-   :class:`datetime` and :class:`time` instances are serialized as a number of
-   seconds, respectively since the ``EPOCH`` for the first two kinds and since
-   midnight for the latter:
+   `Unix time`_: with :data:`DM_UNIX_TIME` :class:`date`, :class:`datetime`
+   and :class:`time` instances are serialized as a number of seconds,
+   respectively since the ``EPOCH`` for the first two kinds and since midnight
+   for the latter:
 
    .. doctest::
 
-      >>> mode = DATETIME_MODE_UNIX_TIME
+      >>> mode = DM_UNIX_TIME
       >>> dumps([now, now.date(), now.time()], datetime_mode=mode)
       '[1472409071.084418,1472335200.0,73871.084418]'
       >>> unixtime = float(dumps(now, datetime_mode=mode))
       >>> datetime.fromtimestamp(unixtime, here) == now
       True
 
-   Combining it with the :data:`DATETIME_MODE_ONLY_SECONDS` will produce
-   integer values instead, dropping *microseconds*:
+   Combining it with the :data:`DM_ONLY_SECONDS` will produce integer values
+   instead, dropping *microseconds*:
 
    .. doctest::
 
-      >>> mode = DATETIME_MODE_UNIX_TIME | DATETIME_MODE_ONLY_SECONDS
+      >>> mode = DM_UNIX_TIME | DM_ONLY_SECONDS
       >>> dumps([now, now.date(), now.time()], datetime_mode=mode)
       '[1472409071,1472335200,73871]'
 
-   It can be used combined with :data:`DATETIME_MODE_SHIFT_TO_UTC` to obtain the
+   It can be used combined with :data:`DM_SHIFT_TO_UTC` to obtain the
    timestamp of the corresponding UTC_ time:
 
-      >>> mode = DATETIME_MODE_UNIX_TIME | DATETIME_MODE_SHIFT_TO_UTC
+      >>> mode = DM_UNIX_TIME | DM_SHIFT_TO_UTC
       >>> dumps(now, datetime_mode=mode)
       '1472409071.084418'
 
-   As above, when you know that your values are in the UTC_ timezone, you can use the
-   :data:`DATETIME_MODE_NAIVE_IS_UTC` flag to get the right result:
+   As above, when you know that your values are in the UTC_ timezone, you can
+   use the :data:`DM_NAIVE_IS_UTC` flag to get the right result:
 
    .. doctest::
 
       >>> a_long_time_ago = datetime(1968, 3, 18, 9, 10, 0, 0)
-      >>> mode = DATETIME_MODE_UNIX_TIME | DATETIME_MODE_NAIVE_IS_UTC
+      >>> mode = DM_UNIX_TIME | DM_NAIVE_IS_UTC
       >>> dumps([a_long_time_ago, a_long_time_ago.date(), a_long_time_ago.time()],
       ...       datetime_mode=mode)
       '[-56472600.0,-56505600.0,33000.0]'
@@ -429,21 +424,19 @@
 
       >>> loads('"2016-01-02T01:02:03+01:00"')
       '2016-01-02T01:02:03+01:00'
-      >>> loads('"2016-01-02T01:02:03+01:00"',
-      ...       datetime_mode=DATETIME_MODE_ISO8601)
+      >>> loads('"2016-01-02T01:02:03+01:00"', datetime_mode=DM_ISO8601)
       datetime.datetime(2016, 1, 2, 1, 2, 3, tzinfo=...delta(0, 3600)))
-      >>> loads('"2016-01-02"', datetime_mode=DATETIME_MODE_ISO8601)
+      >>> loads('"2016-01-02"', datetime_mode=DM_ISO8601)
       datetime.date(2016, 1, 2)
-      >>> loads('"01:02:03+01:00"',
-      ...       datetime_mode=DATETIME_MODE_ISO8601)
+      >>> loads('"01:02:03+01:00"', datetime_mode=DM_ISO8601)
       datetime.time(1, 2, 3, tzinfo=...delta(0, 3600)))
 
-   It can be combined with :data:`DATETIME_MODE_SHIFT_TO_UTC` to *always*
-   obtain values in the UTC_ timezone:
+   It can be combined with :data:`DM_SHIFT_TO_UTC` to *always* obtain values
+   in the UTC_ timezone:
 
    .. doctest::
 
-      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_SHIFT_TO_UTC
+      >>> mode = DM_ISO8601 | DM_SHIFT_TO_UTC
       >>> loads('"2016-01-02T01:02:03+01:00"', datetime_mode=mode)
       datetime.datetime(2016, 1, 2, 0, 2, 3, tzinfo=...utc)
 
@@ -455,7 +448,7 @@
 
       .. doctest::
 
-         >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_SHIFT_TO_UTC
+         >>> mode = DM_ISO8601 | DM_SHIFT_TO_UTC
          >>> loads('"00:01:02+00:00"', datetime_mode=mode)
          datetime.time(0, 1, 2, tzinfo=...utc)
          >>> loads('"00:01:02+01:00"', datetime_mode=mode)
@@ -463,12 +456,12 @@
            ...
          ValueError: ... Time literal cannot be shifted to UTC: 00:01:02+01:00
 
-   If you combine it with :data:`DATETIME_MODE_NAIVE_IS_UTC` then all values
-   without a timezone will be assumed to be relative to UTC_:
+   If you combine it with :data:`DM_NAIVE_IS_UTC` then all values without a
+   timezone will be assumed to be relative to UTC_:
 
    .. doctest::
 
-      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_NAIVE_IS_UTC
+      >>> mode = DM_ISO8601 | DM_NAIVE_IS_UTC
       >>> loads('"2016-01-02T01:02:03"', datetime_mode=mode)
       datetime.datetime(2016, 1, 2, 1, 2, 3, tzinfo=...utc)
       >>> loads('"2016-01-02T01:02:03+01:00"', datetime_mode=mode)
@@ -476,12 +469,12 @@
       >>> loads('"01:02:03"', datetime_mode=mode)
       datetime.time(1, 2, 3, tzinfo=...utc)
 
-   Yet another combination is with :data:`DATETIME_MODE_IGNORE_TZ` to ignore
-   the timezone and obtain naïve values:
+   Yet another combination is with :data:`DM_IGNORE_TZ` to ignore the timezone
+   and obtain naïve values:
 
    .. doctest::
 
-      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_IGNORE_TZ
+      >>> mode = DM_ISO8601 | DM_IGNORE_TZ
       >>> loads('"2016-01-02T01:02:03+01:00"', datetime_mode=mode)
       datetime.datetime(2016, 1, 2, 1, 2, 3)
       >>> loads('"01:02:03+01:00"', datetime_mode=mode)
@@ -489,13 +482,12 @@
 
    .. _no-unix-time-loads:
 
-   The :data:`DATETIME_MODE_UNIX_TIME` cannot be used here, because there
-   isn't a reasonable heuristic to disambiguate between plain numbers and
-   timestamps:
+   The :data:`DM_UNIX_TIME` cannot be used here, because there isn't a
+   reasonable heuristic to disambiguate between plain numbers and timestamps:
 
    .. doctest::
 
-      >>> loads('[1,2,3]', datetime_mode=DATETIME_MODE_UNIX_TIME)
+      >>> loads('[1,2,3]', datetime_mode=DM_UNIX_TIME)
       Traceback (most recent call last):
         File "<stdin>", line 1, in <module>
       ValueError: Invalid datetime_mode, can deserialize only from ISO8601

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,24 +18,49 @@
 
 .. data:: DATETIME_MODE_NONE
 
-   This is the default ``datetime_mode``: *neither* :class:`datetime` *nor*
-   :class:`date` instances are recognized by :func:`dumps` and :func:`loads`.
+   This is the default ``datetime_mode``: *neither* :class:`date` *nor*
+   :class:`datetime` *nor* :class:`time` instances are recognized by
+   :func:`dumps` and :func:`loads`.
 
 .. data:: DATETIME_MODE_ISO8601
 
    In this ``datetime_mode`` mode :func:`dumps` and :func:`loads` handle
-   :class:`datetime` *and* :class:`date` instances representing those values
-   using the `ISO 8601`_ format.
+   :class:`date`, :class:`datetime` *and* :class:`date` instances representing
+   those values using the `ISO 8601`_ format.
 
-.. data:: DATETIME_MODE_ISO8601_IGNORE_TZ
+.. data:: DATETIME_MODE_UNIX_TIME
 
-   This is like :data:`DATETIME_MODE_ISO8601` except that the value's timezone
-   is ignored.
+   This mode tells RapidJSON to serialize :class:`date`, :class:`datetime` and
+   :class:`time` as *numeric timestamps*: for the formers it is exactly the
+   result of their :meth:`timestamp` method, that is as the number of seconds
+   passed since ``EPOCH``; ``date`` instances are serialized as the
+   corresponding ``datetime`` instance with all the `time` slots set to 0;
+   ``time`` instances are serialized as the number of seconds since midnight.
 
-.. data:: DATETIME_MODE_ISO8601_UTC
+   Since this is obviously *irreversible*, this flag is usable **only** for
+   :func:`dumps`: an error is raised when passed to :func:`loads`.
 
-   This is like :data:`DATETIME_MODE_ISO8601` except that the times are always
-   *shifted* to the UTC_ timezone.
+.. data:: DATETIME_MODE_ONLY_SECONDS
+
+   This is usable in combination with :data:`DATETIME_MODE_UNIX_TIME` so that
+   an integer representation is used, ignoring *microseconds*.
+
+.. data:: DATETIME_MODE_IGNORE_TZ
+
+   This can be used combined with :data:`DATETIME_MODE_ISO8601` or
+   :data:`DATETIME_MODE_UNIX_TIME`, to ignore the value's timezones.
+
+.. data:: DATETIME_MODE_NAIVE_IS_UTC
+
+   This can be used combined with :data:`DATETIME_MODE_ISO8601` or
+   :data:`DATETIME_MODE_UNIX_TIME`, to tell RapidJSON that the naïve values
+   (that is, without an explicit timezone) are already in UTC_ timezone.
+
+.. data:: DATETIME_MODE_SHIFT_TO_UTC
+
+   This can be used combined with :data:`DATETIME_MODE_ISO8601` or
+   :data:`DATETIME_MODE_UNIX_TIME`, to always *shift* values the UTC_
+   timezone.
 
 .. data:: UUID_MODE_NONE
 
@@ -58,9 +83,12 @@
 
 .. testsetup::
 
-    from rapidjson import (dumps, loads, DATETIME_MODE_NONE, DATETIME_MODE_ISO8601,
-                           DATETIME_MODE_ISO8601_IGNORE_TZ, DATETIME_MODE_ISO8601_UTC,
-                           UUID_MODE_NONE, UUID_MODE_CANONICAL, UUID_MODE_HEX)
+   from rapidjson import (dumps, loads,
+                          DATETIME_MODE_NONE, DATETIME_MODE_ISO8601,
+                          DATETIME_MODE_UNIX_TIME, DATETIME_MODE_ONLY_SECONDS,
+                          DATETIME_MODE_IGNORE_TZ, DATETIME_MODE_NAIVE_IS_UTC,
+                          DATETIME_MODE_SHIFT_TO_UTC,
+                          UUID_MODE_NONE, UUID_MODE_CANONICAL, UUID_MODE_HEX)
 
 .. function:: dumps(obj, skipkeys=False, ensure_ascii=True, allow_nan=True, indent=None, \
                     default=None, sort_keys=False, use_decimal=False, \
@@ -77,8 +105,8 @@
                           alphabetically
    :param bool use_decimal: whether :class:`Decimal` should be handled
    :param int max_recursion_depth: maximum depth for nested structures
-   :param int datetime_mode: how should :class:`datetime` and :class:`date`
-                             instances be handled
+   :param int datetime_mode: how should :class:`datetime`, :class:`time` and
+                             :class:`date` instances be handled
    :param int uuid_mode: how should :class:`UUID` instances be handled
    :returns: A Python :class:`str` instance.
 
@@ -219,47 +247,100 @@
         File "<stdin>", line 1, in <module>
       OverflowError: Max recursion depth reached
 
-   By default :class:`date` and :class:`datetime` instances are not
-   serializable. When `datetime_mode` is set to :data:`DATETIME_MODE_ISO8601`
+   By default :class:`date`, :class:`datetime` and :class:`time` instances are
+   not serializable. When `datetime_mode` is set to :data:`DATETIME_MODE_ISO8601`
    those values are serialized using the common `ISO 8601`_ format:
 
    .. doctest::
 
-      >>> from datetime import date, datetime
-      >>> today = date.today()
-      >>> right_now = datetime.now()
-      >>> dumps({'date': today, 'timestamp': right_now})
+      >>> from datetime import datetime
+      >>> right_now = datetime(2016, 8, 28, 13, 14, 52, 277256)
+      >>> date = right_now.date()
+      >>> time = right_now.time()
+      >>> dumps({'date': date, 'time': time, 'timestamp': right_now})
       Traceback (most recent call last):
         File "<stdin>", line 1, in <module>
       TypeError: datetime(…) is not JSON serializable
-      >>> dumps({'a date': today, 'a timestamp': right_now},
-      ...       datetime_mode=DATETIME_MODE_ISO8601) # doctest: +SKIP
-      '{"timestamp":"2016-08-28T13:14:52.277256","date":"2016-08-28"}'
+      >>> dumps(['date', date, 'time', time, 'timestamp', right_now],
+      ...       datetime_mode=DATETIME_MODE_ISO8601)
+      '["date","2016-08-28","time","13:14:52.277256","timestamp","2016-08-28T13:14:52.277256"]'
 
-   Another mode is :data:`DATETIME_MODE_ISO8601_UTC`, that *shifts* all
-   timestamps to the UTC_ timezone before serializing them:
+   The `right_now` value is a naïve datetime (because it does not carry the
+   timezone information) and is normally assumed to be in the local timezone,
+   whatever your system thinks it is. When you instead *know* that your value,
+   even being naïve are actually in the UTC_ timezone, you can use the
+   :data:`DATETIME_MODE_NAIVE_IS_UTC` flag to inform RapidJSON about that:
+
+   .. doctest::
+
+      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_NAIVE_IS_UTC
+      >>> dumps(['time', time, 'timestamp', right_now], datetime_mode=mode)
+      '["time","13:14:52.277256+00:00","timestamp","2016-08-28T13:14:52.277256+00:00"]'
+
+   A variant is :data:`DATETIME_MODE_SHIFT_TO_UTC`, that *shifts* all datetime
+   values to the UTC_ timezone before serializing them:
 
    .. doctest::
 
       >>> from datetime import timedelta, timezone
       >>> here = timezone(timedelta(hours=2))
-      >>> now = datetime.now(here)
-      >>> dumps(now)
-      Traceback (most recent call last):
-        File "<stdin>", line 1, in <module>
-      TypeError: datetime.datetime(…) is not JSON serializable
-      >>> dumps(now, datetime_mode=DATETIME_MODE_ISO8601) # doctest: +SKIP
+      >>> now = datetime(2016, 8, 28, 20, 31, 11, 84418, here)
+      >>> dumps(now, datetime_mode=DATETIME_MODE_ISO8601)
       '"2016-08-28T20:31:11.084418+02:00"'
-      >>> dumps(now, datetime_mode=DATETIME_MODE_ISO8601_UTC) # doctest: +SKIP
+      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_SHIFT_TO_UTC
+      >>> dumps(now, datetime_mode=mode)
       '"2016-08-28T18:31:11.084418+00:00"'
 
-   With :data:`DATETIME_MODE_ISO8601_IGNORE_TZ` the timezone, if present, is
-   simply omitted:
+   With :data:`DATETIME_MODE_IGNORE_TZ` the timezone, if present, is simply
+   omitted:
 
    .. doctest::
 
-      >>> dumps(now, datetime_mode=DATETIME_MODE_ISO8601_IGNORE_TZ) # doctest: +SKIP
+      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_IGNORE_TZ
+      >>> dumps(now, datetime_mode=mode)
       '"2016-08-28T20:31:11.084418"'
+
+   Another :ref:`one-way only <no-unix-time-loads>` alternative format is
+   `Unix time`_: with :data:`DATETIME_MODE_UNIX_TIME` :class:`date`,
+   :class:`datetime` and :class:`time` instances are serialized as a number of
+   seconds, respectively since the ``EPOCH`` for the first two kinds and since
+   midnight for the latter:
+
+   .. doctest::
+
+      >>> mode = DATETIME_MODE_UNIX_TIME
+      >>> dumps([now, now.date(), now.time()], datetime_mode=mode)
+      '[1472409071.084418,1472335200.0,73871.084418]'
+      >>> unixtime = float(dumps(now, datetime_mode=mode))
+      >>> datetime.fromtimestamp(unixtime, here) == now
+      True
+
+   Combining it with the :data:`DATETIME_MODE_ONLY_SECONDS` will produce
+   integer values instead, dropping *microseconds*:
+
+   .. doctest::
+
+      >>> mode = DATETIME_MODE_UNIX_TIME | DATETIME_MODE_ONLY_SECONDS
+      >>> dumps([now, now.date(), now.time()], datetime_mode=mode)
+      '[1472409071,1472335200,73871]'
+
+   It can be used combined with :data:`DATETIME_MODE_SHIFT_TO_UTC` to obtain the
+   timestamp of the corresponding UTC_ time:
+
+      >>> mode = DATETIME_MODE_UNIX_TIME | DATETIME_MODE_SHIFT_TO_UTC
+      >>> dumps(now, datetime_mode=mode)
+      '1472409071.084418'
+
+   As above, when you know that your values are in the UTC_ timezone, you can use the
+   :data:`DATETIME_MODE_NAIVE_IS_UTC` flag to get the right result:
+
+   .. doctest::
+
+      >>> a_long_time_ago = datetime(1968, 3, 18, 9, 10, 0, 0)
+      >>> mode = DATETIME_MODE_UNIX_TIME | DATETIME_MODE_NAIVE_IS_UTC
+      >>> dumps([a_long_time_ago, a_long_time_ago.date(), a_long_time_ago.time()],
+      ...       datetime_mode=mode)
+      '[-56472600.0,-56505600.0,33000.0]'
 
    Likewise, to handle :class:`UUID` instances there are two modes that can be
    specified with the `uuid_mode` argument, that will use the string
@@ -289,8 +370,8 @@
    :param bool use_decimal: whether :class:`Decimal` should be used for float
                             values
    :param bool allow_nan: whether ``NaN`` values are recognized
-   :param int datetime_mode: how should :class:`datetime` and :class:`date`
-                             instances be handled
+   :param int datetime_mode: how should :class:`date`, :class:`datetime` and
+                             :class:`time` instances be handled
    :param int uuid_mode: how should :class:`UUID` instances be handled
    :returns: An equivalent Python object.
 
@@ -341,8 +422,8 @@
       ValueError: … Out of range float values are not JSON compliant
 
    With `datetime_mode` you can enable recognition of string literals
-   containing an `ISO 8601`_ representation as either :class:`date` or
-   :class:`datetime` instances:
+   containing an `ISO 8601`_ representation as either :class:`date`,
+   :class:`datetime` or :class:`time` instances:
 
    .. doctest::
 
@@ -351,14 +432,73 @@
       >>> loads('"2016-01-02T01:02:03+01:00"',
       ...       datetime_mode=DATETIME_MODE_ISO8601)
       datetime.datetime(2016, 1, 2, 1, 2, 3, tzinfo=...delta(0, 3600)))
-      >>> loads('"2016-01-02T01:02:03+01:00"',
-      ...       datetime_mode=DATETIME_MODE_ISO8601_UTC)
-      datetime.datetime(2016, 1, 2, 0, 2, 3, tzinfo=...utc)
-      >>> loads('"2016-01-02T01:02:03+01:00"',
-      ...       datetime_mode=DATETIME_MODE_ISO8601_IGNORE_TZ)
-      datetime.datetime(2016, 1, 2, 1, 2, 3)
       >>> loads('"2016-01-02"', datetime_mode=DATETIME_MODE_ISO8601)
       datetime.date(2016, 1, 2)
+      >>> loads('"01:02:03+01:00"',
+      ...       datetime_mode=DATETIME_MODE_ISO8601)
+      datetime.time(1, 2, 3, tzinfo=...delta(0, 3600)))
+
+   It can be combined with :data:`DATETIME_MODE_SHIFT_TO_UTC` to *always*
+   obtain values in the UTC_ timezone:
+
+   .. doctest::
+
+      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_SHIFT_TO_UTC
+      >>> loads('"2016-01-02T01:02:03+01:00"', datetime_mode=mode)
+      datetime.datetime(2016, 1, 2, 0, 2, 3, tzinfo=...utc)
+
+   .. note::
+
+      This option is somewhat limited when the value is a non-naïve time literal
+      because negative values cannot be represented by the underlying Python
+      type, so it cannot adapt such values reliably:
+
+      .. doctest::
+
+         >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_SHIFT_TO_UTC
+         >>> loads('"00:01:02+00:00"', datetime_mode=mode)
+         datetime.time(0, 1, 2, tzinfo=...utc)
+         >>> loads('"00:01:02+01:00"', datetime_mode=mode)
+         Traceback (most recent call last):
+           ...
+         ValueError: ... Time literal cannot be shifted to UTC: 00:01:02+01:00
+
+   If you combine it with :data:`DATETIME_MODE_NAIVE_IS_UTC` then all values
+   without a timezone will be assumed to be relative to UTC_:
+
+   .. doctest::
+
+      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_NAIVE_IS_UTC
+      >>> loads('"2016-01-02T01:02:03"', datetime_mode=mode)
+      datetime.datetime(2016, 1, 2, 1, 2, 3, tzinfo=...utc)
+      >>> loads('"2016-01-02T01:02:03+01:00"', datetime_mode=mode)
+      datetime.datetime(2016, 1, 2, 1, 2, 3, tzinfo=...delta(0, 3600)))
+      >>> loads('"01:02:03"', datetime_mode=mode)
+      datetime.time(1, 2, 3, tzinfo=...utc)
+
+   Yet another combination is with :data:`DATETIME_MODE_IGNORE_TZ` to ignore
+   the timezone and obtain naïve values:
+
+   .. doctest::
+
+      >>> mode = DATETIME_MODE_ISO8601 | DATETIME_MODE_IGNORE_TZ
+      >>> loads('"2016-01-02T01:02:03+01:00"', datetime_mode=mode)
+      datetime.datetime(2016, 1, 2, 1, 2, 3)
+      >>> loads('"01:02:03+01:00"', datetime_mode=mode)
+      datetime.time(1, 2, 3)
+
+   .. _no-unix-time-loads:
+
+   The :data:`DATETIME_MODE_UNIX_TIME` cannot be used here, because there
+   isn't a reasonable heuristic to disambiguate between plain numbers and
+   timestamps:
+
+   .. doctest::
+
+      >>> loads('[1,2,3]', datetime_mode=DATETIME_MODE_UNIX_TIME)
+      Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+      ValueError: Invalid datetime_mode, can deserialize only from ISO8601
 
    With `uuid_mode` you can enable recognition of string literals containing
    two different representations of :class:`UUID` values:
@@ -384,3 +524,4 @@
 .. _ISO 8601: https://en.wikipedia.org/wiki/ISO_8601
 .. _RapidJSON: https://github.com/miloyip/rapidjson
 .. _UTC: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
+.. _Unix time: https://en.wikipedia.org/wiki/Unix_time

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -66,7 +66,7 @@ types:
 .. doctest::
 
     >>> import datetime, decimal, uuid
-    >>> from rapidjson import DATETIME_MODE_ISO8601, UUID_MODE_CANONICAL
+    >>> from rapidjson import DM_ISO8601, UUID_MODE_CANONICAL
     >>> some_day = datetime.date(2016, 8, 28)
     >>> some_timestamp = datetime.datetime(2016, 8, 28, 13, 14, 15)
     >>> dumps({'a date': some_day, 'a timestamp': some_timestamp})
@@ -74,13 +74,13 @@ types:
       File "<stdin>", line 1, in <module>
     TypeError: datetime.datetime(…) is not JSON serializable
     >>> dumps({'a date': some_day, 'a timestamp': some_timestamp},
-    ...       datetime_mode=DATETIME_MODE_ISO8601,
+    ...       datetime_mode=DM_ISO8601,
     ...       sort_keys=True) # for doctests
     '{"a date":"2016-08-28","a timestamp":"2016-08-28T13:14:15"}'
     >>> as_json = _
     >>> pprint(loads(as_json))
     {'a date': '2016-08-28', 'a timestamp': '2016-08-28T13:14:15'}
-    >>> pprint(loads(as_json, datetime_mode=DATETIME_MODE_ISO8601))
+    >>> pprint(loads(as_json, datetime_mode=DM_ISO8601))
     {'a date': datetime.date(2016, 8, 28),
      'a timestamp': datetime.datetime(2016, 8, 28, 13, 14, 15)}
     >>> some_uuid = uuid.uuid5(uuid.NAMESPACE_DNS, 'python.org')

--- a/python-rapidjson/rapidjson.cpp
+++ b/python-rapidjson/rapidjson.cpp
@@ -53,14 +53,38 @@ struct HandlerContext {
 
 enum DatetimeMode {
     DATETIME_MODE_NONE = 0,
-    DATETIME_MODE_ISO8601 = 1,
-    DATETIME_MODE_ISO8601_IGNORE_TZ = 2,
-    DATETIME_MODE_ISO8601_UTC = 3
+    // Formats
+    DATETIME_MODE_ISO8601 = 1,        // Bidirectional ISO8601 for datetimes, dates and times
+    DATETIME_MODE_UNIX_TIME = 2,      // Serialization only, "Unix epoch"-based number of seconds
+    // Options
+    DATETIME_MODE_ONLY_SECONDS = 16,  // Truncate values to the whole second, ignoring micro seconds
+    DATETIME_MODE_IGNORE_TZ = 32,     // Ignore timezones
+    DATETIME_MODE_NAIVE_IS_UTC = 64,  // Assume naive datetime are in UTC timezone
+    DATETIME_MODE_SHIFT_TO_UTC = 128, // Shift to/from UTC
 };
+
+
+#define DATETIME_MODE_FORMATS_MASK 0x0f
+
+
+static inline int
+datetime_mode_format(DatetimeMode mode) {
+    return mode & DATETIME_MODE_FORMATS_MASK;
+}
+
+
+static inline bool
+valid_datetime_mode(int mode) {
+    return (mode >= 0
+            && ((mode & DATETIME_MODE_FORMATS_MASK) <= DATETIME_MODE_UNIX_TIME)
+            && (mode == 0 || (mode & DATETIME_MODE_FORMATS_MASK) != 0));
+}
 
 
 static int
 days_per_month(int year, int month) {
+    assert(month >= 1);
+    assert(month <= 12);
     if (month == 1 || month == 3 || month == 5 || month == 7
         || month == 8 || month == 10 || month == 12)
         return 31;
@@ -398,7 +422,7 @@ struct PyHandler {
                 if (length == 9)
                     res = str[8] == 'Z';
                 else if (length == 14)
-                    res = str[8] == '-';
+                    res = str[8] == '-' || str[8] == '+';
                 else if (length > 8)
                     res = str[8] == '.';
                 if (res && (length == 13 || length == 16)) {
@@ -533,52 +557,53 @@ struct PyHandler {
             if (length == 8 || length == 9 || length == 14)
                 usecs = 0;
             else {
-                usecs = digit(9)*100000
+                usecs = digit(9) * 100000
                     + digit(10) * 10000
                     + digit(11) * 1000;
                 if (length == 15 || length == 16 || length == 21)
-                    usecs += digit(12)*100
+                    usecs += digit(12) * 100
                         + digit(13) * 10
                         + digit(14);
             }
-            if (datetimeMode == DATETIME_MODE_ISO8601_IGNORE_TZ
-                || length == 8 || length == 12 || length == 15)
-                value = PyTime_FromTime(hours, mins, secs, usecs);
-            else if (length == 9 || length == 13 || length == 16)
+            if ((length == 8 && datetimeMode & DATETIME_MODE_NAIVE_IS_UTC)
+                || length == 9 || length == 13 || length == 16)
                 value = PyDateTimeAPI->Time_FromTime(
                     hours, mins, secs, usecs, timezone_utc,
                     PyDateTimeAPI->TimeType);
+            else if (datetimeMode & DATETIME_MODE_IGNORE_TZ
+                     || length == 8 || length == 12 || length == 15)
+                value = PyTime_FromTime(hours, mins, secs, usecs);
             else /* if (length == 14 || length == 18 || length == 21) */ {
                 int secsoffset = ((digit(length-5)*10 + digit(length-4)) * 3600
                                   + (digit(length-2)*10 + digit(length-1)) * 60);
                 if (str[length-6] == '-')
                     secsoffset = -secsoffset;
-                PyObject* offset = PyDateTimeAPI->Delta_FromDelta(
-                    0, secsoffset, 0, 1, PyDateTimeAPI->DeltaType);
-                if (offset == NULL)
+                if (datetimeMode & DATETIME_MODE_SHIFT_TO_UTC && secsoffset) {
+                    PyErr_Format(PyExc_ValueError,
+                                 "Time literal cannot be shifted to UTC: %s", str);
                     value = NULL;
-                else {
-                    PyObject* tz = PyObject_CallFunctionObjArgs(
-                        timezone_type, offset, NULL);
-                    Py_DECREF(offset);
-                    if (tz == NULL)
-                        value = NULL;
-                    else {
+                } else {
+                    if (datetimeMode & DATETIME_MODE_SHIFT_TO_UTC) {
                         value = PyDateTimeAPI->Time_FromTime(
-                            hours, mins, secs, usecs, tz,
+                            hours, mins, secs, usecs, timezone_utc,
                             PyDateTimeAPI->TimeType);
-                        Py_DECREF(tz);
-
-                        if (value != NULL && datetimeMode == DATETIME_MODE_ISO8601_UTC) {
-                            PyObject* asUTC = PyObject_CallMethodObjArgs(
-                                value, astimezone_name, timezone_utc, NULL);
-
-                            Py_DECREF(value);
-
-                            if (asUTC == NULL)
+                    } else {
+                        PyObject* offset = PyDateTimeAPI->Delta_FromDelta(
+                            0, secsoffset, 0, 1, PyDateTimeAPI->DeltaType);
+                        if (offset == NULL)
+                            value = NULL;
+                        else {
+                            PyObject* tz = PyObject_CallFunctionObjArgs(
+                                timezone_type, offset, NULL);
+                            Py_DECREF(offset);
+                            if (tz == NULL)
                                 value = NULL;
-                            else
-                                value = asUTC;
+                            else {
+                                value = PyDateTimeAPI->Time_FromTime(
+                                    hours, mins, secs, usecs, tz,
+                                    PyDateTimeAPI->TimeType);
+                                Py_DECREF(tz);
+                            }
                         }
                     }
                 }
@@ -624,14 +649,15 @@ struct PyHandler {
                         + digit(24)*10
                         + digit(25);
             }
-            if (datetimeMode == DATETIME_MODE_ISO8601_IGNORE_TZ
-                || length == 19 || length == 23 || length == 26)
-                value = PyDateTime_FromDateAndTime(
-                    year, month, day, hours, mins, secs, usecs);
-            else if (length == 20 || length == 24 || length == 27)
+            if ((length == 19 && datetimeMode & DATETIME_MODE_NAIVE_IS_UTC)
+                || length == 20 || length == 24 || length == 27)
                 value = PyDateTimeAPI->DateTime_FromDateAndTime(
                     year, month, day, hours, mins, secs, usecs,
                     timezone_utc, PyDateTimeAPI->DateTimeType);
+            else if (datetimeMode & DATETIME_MODE_IGNORE_TZ
+                || length == 19 || length == 23 || length == 26)
+                value = PyDateTime_FromDateAndTime(
+                    year, month, day, hours, mins, secs, usecs);
             else /* if (length == 25 || length == 29 || length == 32) */ {
                 int secsoffset = ((digit(length-5)*10 + digit(length-4)) * 3600
                                   + (digit(length-2)*10 + digit(length-1)) * 60);
@@ -653,7 +679,7 @@ struct PyHandler {
                             tz, PyDateTimeAPI->DateTimeType);
                         Py_DECREF(tz);
 
-                        if (value != NULL && datetimeMode == DATETIME_MODE_ISO8601_UTC) {
+                        if (value != NULL && datetimeMode & DATETIME_MODE_SHIFT_TO_UTC) {
                             PyObject* asUTC = PyObject_CallMethodObjArgs(
                                 value, astimezone_name, timezone_utc, NULL);
 
@@ -730,6 +756,7 @@ struct PyHandler {
     }
 };
 
+
 static PyObject*
 loads(PyObject* self, PyObject* args, PyObject* kwargs)
 {
@@ -788,22 +815,32 @@ loads(PyObject* self, PyObject* args, PyObject* kwargs)
     }
 
     if (datetimeModeObj) {
-        if (PyLong_Check(datetimeModeObj)) {
-            datetimeMode = (DatetimeMode) PyLong_AsLong(datetimeModeObj);
-            if (datetimeMode < DATETIME_MODE_NONE
-                || datetimeMode > DATETIME_MODE_ISO8601_UTC) {
+        if (datetimeModeObj == Py_None)
+            datetimeMode = DATETIME_MODE_NONE;
+        else if (PyLong_Check(datetimeModeObj)) {
+            int mode = PyLong_AsLong(datetimeModeObj);
+            if (!valid_datetime_mode(mode)) {
                 PyErr_SetString(PyExc_ValueError, "Invalid datetime_mode");
+                return NULL;
+            }
+            datetimeMode = (DatetimeMode) mode;
+            if (datetimeMode && datetime_mode_format(datetimeMode) != DATETIME_MODE_ISO8601) {
+                PyErr_SetString(PyExc_ValueError,
+                                "Invalid datetime_mode, can deserialize only from ISO8601");
                 return NULL;
             }
         }
         else {
-            PyErr_SetString(PyExc_TypeError, "datetime_mode must be an integer value");
+            PyErr_SetString(PyExc_TypeError,
+                            "datetime_mode must be a non-negative integer value or None");
             return NULL;
         }
     }
 
     if (uuidModeObj) {
-        if (PyLong_Check(uuidModeObj)) {
+        if (uuidModeObj == Py_None)
+            uuidMode = UUID_MODE_NONE;
+        else if (PyLong_Check(uuidModeObj)) {
             uuidMode = (UuidMode) PyLong_AsLong(uuidModeObj);
             if (uuidMode < UUID_MODE_NONE || uuidMode > UUID_MODE_HEX) {
                 PyErr_SetString(PyExc_ValueError, "Invalid uuid_mode");
@@ -811,7 +848,8 @@ loads(PyObject* self, PyObject* args, PyObject* kwargs)
             }
         }
         else {
-            PyErr_SetString(PyExc_TypeError, "uuid_mode must be an integer value");
+            PyErr_SetString(PyExc_TypeError,
+                            "uuid_mode must be an integer value or None");
             return NULL;
         }
     }
@@ -1118,18 +1156,40 @@ dumps_internal(
             const int TIMEZONE_LEN = 10;
             char timeZone[TIMEZONE_LEN] = { 0 };
 
-            if (datetimeMode != DATETIME_MODE_ISO8601_IGNORE_TZ
+            if (!(datetimeMode & DATETIME_MODE_IGNORE_TZ)
                 && PyObject_HasAttr(object, utcoffset_name)) {
-                PyObject* utcOffset = PyObject_CallMethodObjArgs(object, utcoffset_name, NULL);
+                PyObject* utcOffset = PyObject_CallMethodObjArgs(object,
+                                                                 utcoffset_name,
+                                                                 NULL);
 
                 if (!utcOffset)
                     goto error;
 
-                if (utcOffset != Py_None) {
-                    if (datetimeMode == DATETIME_MODE_ISO8601_UTC
-                        && PyObject_IsTrue(utcOffset)) {
-                        asUTC = PyObject_CallMethodObjArgs(object, astimezone_name,
-                                                           timezone_utc, NULL);
+                if (utcOffset == Py_None) {
+                    // Naive value: maybe assume it's in UTC instead of local time
+                    if (datetimeMode & DATETIME_MODE_NAIVE_IS_UTC) {
+
+                        if (PyDateTime_Check(object)) {
+                            hour = PyDateTime_DATE_GET_HOUR(dtObject);
+                            min = PyDateTime_DATE_GET_MINUTE(dtObject);
+                            sec = PyDateTime_DATE_GET_SECOND(dtObject);
+                            microsec = PyDateTime_DATE_GET_MICROSECOND(dtObject);
+                            year = PyDateTime_GET_YEAR(dtObject);
+                            month = PyDateTime_GET_MONTH(dtObject);
+                            day = PyDateTime_GET_DAY(dtObject);
+
+                            asUTC = PyDateTimeAPI->DateTime_FromDateAndTime(
+                                year, month, day, hour, min, sec, microsec,
+                                timezone_utc, PyDateTimeAPI->DateTimeType);
+                        } else {
+                            hour = PyDateTime_TIME_GET_HOUR(dtObject);
+                            min = PyDateTime_TIME_GET_MINUTE(dtObject);
+                            sec = PyDateTime_TIME_GET_SECOND(dtObject);
+                            microsec = PyDateTime_TIME_GET_MICROSECOND(dtObject);
+                            asUTC = PyDateTimeAPI->Time_FromTime(
+                                hour, min, sec, microsec,
+                                timezone_utc, PyDateTimeAPI->TimeType);
+                        }
 
                         if (asUTC == NULL) {
                             Py_DECREF(utcOffset);
@@ -1137,8 +1197,29 @@ dumps_internal(
                         }
 
                         dtObject = asUTC;
-                        strcpy(timeZone, "+00:00");
-                    } else {
+
+                        if (datetime_mode_format(datetimeMode) == DATETIME_MODE_ISO8601)
+                            strcpy(timeZone, "+00:00");
+                    }
+                } else {
+                    // Timezone-aware value
+                    if (datetimeMode & DATETIME_MODE_SHIFT_TO_UTC) {
+                        // If it's not already in UTC, shift the value
+                        if (PyObject_IsTrue(utcOffset)) {
+                            asUTC = PyObject_CallMethodObjArgs(object, astimezone_name,
+                                                               timezone_utc, NULL);
+
+                            if (asUTC == NULL) {
+                                Py_DECREF(utcOffset);
+                                goto error;
+                            }
+
+                            dtObject = asUTC;
+                        }
+
+                        if (datetime_mode_format(datetimeMode) == DATETIME_MODE_ISO8601)
+                            strcpy(timeZone, "+00:00");
+                    } else if (datetime_mode_format(datetimeMode) == DATETIME_MODE_ISO8601) {
                         int seconds_from_utc = 0;
 
                         if (PyObject_IsTrue(utcOffset)) {
@@ -1173,62 +1254,135 @@ dumps_internal(
                 Py_DECREF(utcOffset);
             }
 
-            if (PyDateTime_Check(dtObject)) {
-                year = PyDateTime_GET_YEAR(dtObject);
-                month = PyDateTime_GET_MONTH(dtObject);
-                day = PyDateTime_GET_DAY(dtObject);
-                hour = PyDateTime_DATE_GET_HOUR(dtObject);
-                min = PyDateTime_DATE_GET_MINUTE(dtObject);
-                sec = PyDateTime_DATE_GET_SECOND(dtObject);
-                microsec = PyDateTime_DATE_GET_MICROSECOND(dtObject);
-                if (microsec > 0) {
-                    snprintf(isoformat,
-                             ISOFORMAT_LEN-1,
-                             "%04d-%02d-%02dT%02d:%02d:%02d.%06d%s",
-                             year, month, day,
-                             hour, min, sec, microsec,
-                             timeZone);
+            if (datetime_mode_format(datetimeMode) == DATETIME_MODE_ISO8601) {
+                if (PyDateTime_Check(dtObject)) {
+                    year = PyDateTime_GET_YEAR(dtObject);
+                    month = PyDateTime_GET_MONTH(dtObject);
+                    day = PyDateTime_GET_DAY(dtObject);
+                    hour = PyDateTime_DATE_GET_HOUR(dtObject);
+                    min = PyDateTime_DATE_GET_MINUTE(dtObject);
+                    sec = PyDateTime_DATE_GET_SECOND(dtObject);
+                    microsec = PyDateTime_DATE_GET_MICROSECOND(dtObject);
+
+                    if (microsec > 0) {
+                        snprintf(isoformat,
+                                 ISOFORMAT_LEN-1,
+                                 "%04d-%02d-%02dT%02d:%02d:%02d.%06d%s",
+                                 year, month, day,
+                                 hour, min, sec, microsec,
+                                 timeZone);
+                    } else {
+                        snprintf(isoformat,
+                                 ISOFORMAT_LEN-1,
+                                 "%04d-%02d-%02dT%02d:%02d:%02d%s",
+                                 year, month, day,
+                                 hour, min, sec,
+                                 timeZone);
+                    }
                 } else {
-                    snprintf(isoformat,
-                             ISOFORMAT_LEN-1,
-                             "%04d-%02d-%02dT%02d:%02d:%02d%s",
-                             year, month, day,
-                             hour, min, sec,
-                             timeZone);
+                    hour = PyDateTime_TIME_GET_HOUR(dtObject);
+                    min = PyDateTime_TIME_GET_MINUTE(dtObject);
+                    sec = PyDateTime_TIME_GET_SECOND(dtObject);
+                    microsec = PyDateTime_TIME_GET_MICROSECOND(dtObject);
+
+                    if (microsec > 0) {
+                        snprintf(isoformat,
+                                 ISOFORMAT_LEN-1,
+                                 "%02d:%02d:%02d.%06d%s",
+                                 hour, min, sec, microsec,
+                                 timeZone);
+                    } else {
+                        snprintf(isoformat,
+                                 ISOFORMAT_LEN-1,
+                                 "%02d:%02d:%02d%s",
+                                 hour, min, sec,
+                                 timeZone);
+                    }
                 }
-            } else {
-                hour = PyDateTime_TIME_GET_HOUR(dtObject);
-                min = PyDateTime_TIME_GET_MINUTE(dtObject);
-                sec = PyDateTime_TIME_GET_SECOND(dtObject);
-                microsec = PyDateTime_TIME_GET_MICROSECOND(dtObject);
-                if (microsec > 0) {
-                    snprintf(isoformat,
-                             ISOFORMAT_LEN-1,
-                             "%02d:%02d:%02d.%06d%s",
-                             hour, min, sec, microsec,
-                             timeZone);
+                writer->String(isoformat);
+            } else /* if (datetimeMode & DATETIME_MODE_UNIX_TIME) */ {
+                if (PyDateTime_Check(dtObject)) {
+                    PyObject* timestampObj;
+
+                    timestampObj = PyObject_CallMethodObjArgs(dtObject, timestamp_name, NULL);
+
+                    if (!timestampObj) {
+                        Py_XDECREF(asUTC);
+                        goto error;
+                    }
+
+                    double timestamp = PyFloat_AsDouble(timestampObj);
+
+                    Py_DECREF(timestampObj);
+
+                    if (datetimeMode & DATETIME_MODE_ONLY_SECONDS)
+                        writer->Int64(timestamp);
+                    else
+                        writer->Double(timestamp);
                 } else {
-                    snprintf(isoformat,
-                             ISOFORMAT_LEN-1,
-                             "%02d:%02d:%02d%s",
-                             hour, min, sec,
-                             timeZone);
+                    hour = PyDateTime_TIME_GET_HOUR(dtObject);
+                    min = PyDateTime_TIME_GET_MINUTE(dtObject);
+                    sec = PyDateTime_TIME_GET_SECOND(dtObject);
+                    microsec = PyDateTime_TIME_GET_MICROSECOND(dtObject);
+
+                    long timestamp = hour * 3600 + min * 60 + sec;
+
+                    if (datetimeMode & DATETIME_MODE_ONLY_SECONDS)
+                        writer->Int64(timestamp);
+                    else
+                        writer->Double(timestamp + (microsec / 1000000.0));
                 }
             }
             Py_XDECREF(asUTC);
-            writer->String(isoformat);
         }
         else if (datetimeMode != DATETIME_MODE_NONE && PyDate_Check(object)) {
             int year = PyDateTime_GET_YEAR(object);
             int month = PyDateTime_GET_MONTH(object);
             int day = PyDateTime_GET_DAY(object);
 
-            const int ISOFORMAT_LEN = 12;
-            char isoformat[ISOFORMAT_LEN];
-            memset(isoformat, 0, ISOFORMAT_LEN);
+            if (datetime_mode_format(datetimeMode) == DATETIME_MODE_ISO8601) {
+                const int ISOFORMAT_LEN = 12;
+                char isoformat[ISOFORMAT_LEN];
+                memset(isoformat, 0, ISOFORMAT_LEN);
 
-            snprintf(isoformat, ISOFORMAT_LEN-1, "%04d-%02d-%02d", year, month, day);
-            writer->String(isoformat);
+                snprintf(isoformat, ISOFORMAT_LEN-1, "%04d-%02d-%02d", year, month, day);
+                writer->String(isoformat);
+            } else /* datetime_mode_format(datetimeMode) == DATETIME_MODE_UNIX_TIME */ {
+                // A date object, take its midnight timestamp
+                PyObject* midnightObj;
+                PyObject* timestampObj;
+
+                if (datetimeMode & (DATETIME_MODE_SHIFT_TO_UTC
+                                    | DATETIME_MODE_NAIVE_IS_UTC))
+                    midnightObj = PyDateTimeAPI->DateTime_FromDateAndTime(
+                        year, month, day, 0, 0, 0, 0,
+                        timezone_utc, PyDateTimeAPI->DateTimeType);
+                else
+                    midnightObj = PyDateTime_FromDateAndTime(year, month, day,
+                                                             0, 0, 0, 0);
+
+                if (!midnightObj) {
+                    goto error;
+                }
+
+                timestampObj = PyObject_CallMethodObjArgs(midnightObj, timestamp_name,
+                                                          NULL);
+
+                Py_DECREF(midnightObj);
+
+                if (!timestampObj) {
+                    goto error;
+                }
+
+                double timestamp = PyFloat_AsDouble(timestampObj);
+
+                Py_DECREF(timestampObj);
+
+                if (datetimeMode & DATETIME_MODE_ONLY_SECONDS)
+                    writer->Int64(timestamp);
+                else
+                    writer->Double(timestamp);
+            }
         }
         else if (uuidMode != UUID_MODE_NONE
                  && PyObject_TypeCheck(object, (PyTypeObject *) uuid_type)) {
@@ -1255,7 +1409,8 @@ dumps_internal(
         }
         else {
             PyObject* repr = PyObject_Repr(object);
-            PyErr_Format(PyExc_TypeError, "%s is not JSON serializable", PyUnicode_AsUTF8(repr));
+            PyErr_Format(PyExc_TypeError, "%s is not JSON serializable",
+                         PyUnicode_AsUTF8(repr));
             Py_XDECREF(repr);
             goto error;
         }
@@ -1352,23 +1507,28 @@ dumps(PyObject* self, PyObject* args, PyObject* kwargs)
         }
     }
 
-    if (datetimeModeObj) {
-        if (PyLong_Check(datetimeModeObj)) {
-            datetimeMode = (DatetimeMode) PyLong_AsLong(datetimeModeObj);
-            if (datetimeMode < DATETIME_MODE_NONE
-                || datetimeMode > DATETIME_MODE_ISO8601_UTC) {
+   if (datetimeModeObj) {
+        if (datetimeModeObj == Py_None)
+            datetimeMode = DATETIME_MODE_NONE;
+        else if (PyLong_Check(datetimeModeObj)) {
+            int mode = PyLong_AsLong(datetimeModeObj);
+            if (!valid_datetime_mode(mode)) {
                 PyErr_SetString(PyExc_ValueError, "Invalid datetime_mode");
                 return NULL;
             }
+            datetimeMode = (DatetimeMode) mode;
         }
         else {
-            PyErr_SetString(PyExc_TypeError, "datetime_mode must be an integer value");
+            PyErr_SetString(PyExc_TypeError,
+                            "datetime_mode must be a non-negative integer value or None");
             return NULL;
         }
     }
 
     if (uuidModeObj) {
-        if (PyLong_Check(uuidModeObj)) {
+        if (uuidModeObj == Py_None)
+            uuidMode = UUID_MODE_NONE;
+        else if (PyLong_Check(uuidModeObj)) {
             uuidMode = (UuidMode) PyLong_AsLong(uuidModeObj);
             if (uuidMode < UUID_MODE_NONE || uuidMode > UUID_MODE_HEX) {
                 PyErr_SetString(PyExc_ValueError, "Invalid uuid_mode");
@@ -1611,10 +1771,16 @@ PyInit_rapidjson()
                             DATETIME_MODE_NONE);
     PyModule_AddIntConstant(m, "DATETIME_MODE_ISO8601",
                             DATETIME_MODE_ISO8601);
-    PyModule_AddIntConstant(m, "DATETIME_MODE_ISO8601_IGNORE_TZ",
-                            DATETIME_MODE_ISO8601_IGNORE_TZ);
-    PyModule_AddIntConstant(m, "DATETIME_MODE_ISO8601_UTC",
-                            DATETIME_MODE_ISO8601_UTC);
+    PyModule_AddIntConstant(m, "DATETIME_MODE_UNIX_TIME",
+                            DATETIME_MODE_UNIX_TIME);
+    PyModule_AddIntConstant(m, "DATETIME_MODE_ONLY_SECONDS",
+                            DATETIME_MODE_ONLY_SECONDS);
+    PyModule_AddIntConstant(m, "DATETIME_MODE_IGNORE_TZ",
+                            DATETIME_MODE_IGNORE_TZ);
+    PyModule_AddIntConstant(m, "DATETIME_MODE_NAIVE_IS_UTC",
+                            DATETIME_MODE_NAIVE_IS_UTC);
+    PyModule_AddIntConstant(m, "DATETIME_MODE_SHIFT_TO_UTC",
+                            DATETIME_MODE_SHIFT_TO_UTC);
 
     PyModule_AddIntConstant(m, "UUID_MODE_NONE",
                             UUID_MODE_NONE);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,5 @@ def pytest_generate_tests(metafunc):
     if 'datetimes_loads_contender' in metafunc.fixturenames:
         metafunc.parametrize('datetimes_loads_contender',
                              [rj.loads,
-                              partial(rj.loads,
-                                      datetime_mode=rj.DATETIME_MODE_ISO8601)],
+                              partial(rj.loads, datetime_mode=rj.DM_ISO8601)],
                              ids=['Ignore datetimes', 'Parse datetimes'])

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -96,6 +96,6 @@ def test_loads(contender, data, benchmark):
 @pytest.mark.benchmark(group='deserialize')
 @pytest.mark.parametrize('data', [datetimes], ids=['256x3 datetimes'])
 def test_loads_datetimes(datetimes_loads_contender, data, benchmark):
-    from rapidjson import dumps, DATETIME_MODE_ISO8601
-    data = dumps(data, datetime_mode=DATETIME_MODE_ISO8601)
+    from rapidjson import dumps, DM_ISO8601
+    data = dumps(data, datetime_mode=DM_ISO8601)
     benchmark(datetimes_loads_contender, data)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -166,74 +166,59 @@ def test_datetime_mode_dumps():
         rj.dumps(d)
 
     with pytest.raises(TypeError):
-        rj.dumps(d, datetime_mode=rj.DATETIME_MODE_NONE)
+        rj.dumps(d, datetime_mode=rj.DM_NONE)
 
-    assert rj.dumps(d, datetime_mode=rj.DATETIME_MODE_ISO8601) == '"%s"' % dstr
-    assert rj.dumps(
-        d, datetime_mode=(rj.DATETIME_MODE_ISO8601 | rj.DATETIME_MODE_IGNORE_TZ)
-    ) == '"%s"' % dstr
+    assert rj.dumps(d, datetime_mode=rj.DM_ISO8601) == '"%s"' % dstr
+    assert rj.dumps(d, datetime_mode=(rj.DM_ISO8601 | rj.DM_IGNORE_TZ)) == '"%s"' % dstr
 
     d = utcd = d.replace(tzinfo=pytz.utc)
     dstr = utcstr = d.isoformat()
 
-    assert rj.dumps(d, datetime_mode=rj.DATETIME_MODE_ISO8601) == '"%s"' % dstr
-    assert rj.dumps(
-        d, datetime_mode=(rj.DATETIME_MODE_ISO8601 | rj.DATETIME_MODE_IGNORE_TZ)
-    ) == '"%s"' % dstr[:-6]
+    assert rj.dumps(d, datetime_mode=rj.DM_ISO8601) == '"%s"' % dstr
+    assert rj.dumps(d, datetime_mode=(rj.DM_ISO8601 | rj.DM_IGNORE_TZ)) == '"%s"' % dstr[:-6]
 
     d = d.astimezone(pytz.timezone('Pacific/Chatham'))
     dstr = d.isoformat()
 
-    assert rj.dumps(d, datetime_mode=rj.DATETIME_MODE_ISO8601) == '"%s"' % dstr
-    assert rj.dumps(
-        d, datetime_mode=(rj.DATETIME_MODE_ISO8601 | rj.DATETIME_MODE_IGNORE_TZ)
-    ) == '"%s"' % dstr[:-6]
+    assert rj.dumps(d, datetime_mode=rj.DM_ISO8601) == '"%s"' % dstr
+    assert rj.dumps(d, datetime_mode=(rj.DM_ISO8601 | rj.DM_IGNORE_TZ)) == '"%s"' % dstr[:-6]
 
     d = d.astimezone(pytz.timezone('Asia/Kathmandu'))
     dstr = d.isoformat()
 
-    assert rj.dumps(d, datetime_mode=rj.DATETIME_MODE_ISO8601) == '"%s"' % dstr
-    assert rj.dumps(
-        d, datetime_mode=(rj.DATETIME_MODE_ISO8601 | rj.DATETIME_MODE_IGNORE_TZ)
-    ) == '"%s"' % dstr[:-6]
+    assert rj.dumps(d, datetime_mode=rj.DM_ISO8601) == '"%s"' % dstr
+    assert rj.dumps(d, datetime_mode=(rj.DM_ISO8601 | rj.DM_IGNORE_TZ)) == '"%s"' % dstr[:-6]
 
     d = d.astimezone(pytz.timezone('America/New_York'))
     dstr = d.isoformat()
 
-    assert rj.dumps(d, datetime_mode=rj.DATETIME_MODE_ISO8601) == '"%s"' % dstr
-    assert rj.dumps(
-        d, datetime_mode=(rj.DATETIME_MODE_ISO8601 | rj.DATETIME_MODE_IGNORE_TZ)
-    ) == '"%s"' % dstr[:-6]
-    assert rj.dumps(
-        d, datetime_mode=(rj.DATETIME_MODE_ISO8601 | rj.DATETIME_MODE_SHIFT_TO_UTC)
-    ) == '"%s"' % utcstr
+    assert rj.dumps(d, datetime_mode=rj.DM_ISO8601) == '"%s"' % dstr
+    assert rj.dumps(d, datetime_mode=(rj.DM_ISO8601 | rj.DM_IGNORE_TZ)) == '"%s"' % dstr[:-6]
+    assert rj.dumps(d, datetime_mode=(rj.DM_ISO8601 | rj.DM_SHIFT_TO_UTC)) == '"%s"' % utcstr
+
+    assert rj.dumps(d, datetime_mode=rj.DM_UNIX_TIME) == str(d.timestamp())
 
     assert rj.dumps(
-        d, datetime_mode=rj.DATETIME_MODE_UNIX_TIME
-    ) == str(d.timestamp())
+        d, datetime_mode=rj.DM_UNIX_TIME | rj.DM_SHIFT_TO_UTC) == str(utcd.timestamp())
 
     assert rj.dumps(
-        d, datetime_mode=rj.DATETIME_MODE_UNIX_TIME | rj.DATETIME_MODE_SHIFT_TO_UTC
-    ) == str(utcd.timestamp())
-
-    assert rj.dumps(
-        d, datetime_mode= rj.DATETIME_MODE_UNIX_TIME | rj.DATETIME_MODE_ONLY_SECONDS
+        d, datetime_mode= rj.DM_UNIX_TIME | rj.DM_ONLY_SECONDS
     ) == str(d.timestamp()).split('.')[0]
 
     d = datetime.now()
 
     assert rj.dumps(
-        d, datetime_mode=rj.DATETIME_MODE_ISO8601 | rj.DATETIME_MODE_NAIVE_IS_UTC
+        d, datetime_mode=rj.DM_ISO8601 | rj.DM_NAIVE_IS_UTC
     ) == '"%s+00:00"' % d.isoformat()
 
     assert rj.dumps(
-        d, datetime_mode=rj.DATETIME_MODE_UNIX_TIME | rj.DATETIME_MODE_NAIVE_IS_UTC
+        d, datetime_mode=rj.DM_UNIX_TIME | rj.DM_NAIVE_IS_UTC
     ) == ('%d.%06d' % (timegm(d.timetuple()), d.microsecond)).rstrip('0')
 
     assert rj.dumps(
-        d, datetime_mode=(rj.DATETIME_MODE_UNIX_TIME
-                          | rj.DATETIME_MODE_NAIVE_IS_UTC
-                          | rj.DATETIME_MODE_ONLY_SECONDS)
+        d, datetime_mode=(rj.DM_UNIX_TIME
+                          | rj.DM_NAIVE_IS_UTC
+                          | rj.DM_ONLY_SECONDS)
     ) == str(timegm(d.timetuple()))
 
 
@@ -244,28 +229,26 @@ def test_datetime_mode_loads():
     utc = datetime.now(pytz.utc)
     utcstr = utc.isoformat()
 
-    jsond = rj.dumps(utc, datetime_mode=rj.DATETIME_MODE_ISO8601)
+    jsond = rj.dumps(utc, datetime_mode=rj.DM_ISO8601)
 
     assert jsond == '"%s"' % utcstr
-    assert rj.loads(jsond, datetime_mode=rj.DATETIME_MODE_ISO8601) == utc
+    assert rj.loads(jsond, datetime_mode=rj.DM_ISO8601) == utc
 
     local = utc.astimezone(pytz.timezone('Europe/Rome'))
     locstr = local.isoformat()
 
-    jsond = rj.dumps(local, datetime_mode=rj.DATETIME_MODE_ISO8601)
+    jsond = rj.dumps(local, datetime_mode=rj.DM_ISO8601)
 
     assert jsond == '"%s"' % locstr
     assert rj.loads(jsond) == locstr
-    assert rj.loads(jsond, datetime_mode=rj.DATETIME_MODE_ISO8601) == local
+    assert rj.loads(jsond, datetime_mode=rj.DM_ISO8601) == local
 
-    load_as_utc = rj.loads(jsond, datetime_mode=(rj.DATETIME_MODE_ISO8601
-                                                 | rj.DATETIME_MODE_SHIFT_TO_UTC))
+    load_as_utc = rj.loads(jsond, datetime_mode=(rj.DM_ISO8601 | rj.DM_SHIFT_TO_UTC))
 
     assert load_as_utc == utc
     assert not load_as_utc.utcoffset()
 
-    load_as_naive = rj.loads(jsond, datetime_mode=(rj.DATETIME_MODE_ISO8601
-                                                   | rj.DATETIME_MODE_IGNORE_TZ))
+    load_as_naive = rj.loads(jsond, datetime_mode=(rj.DM_ISO8601 | rj.DM_IGNORE_TZ))
 
     assert load_as_naive == local.replace(tzinfo=None)
 
@@ -277,8 +260,8 @@ def test_datetime_values(value):
     with pytest.raises(TypeError):
         rj.dumps(value)
 
-    dumped = rj.dumps(value, datetime_mode=rj.DATETIME_MODE_ISO8601)
-    loaded = rj.loads(dumped, datetime_mode=rj.DATETIME_MODE_ISO8601)
+    dumped = rj.dumps(value, datetime_mode=rj.DM_ISO8601)
+    loaded = rj.loads(dumped, datetime_mode=rj.DM_ISO8601)
     assert loaded == value
 
 
@@ -315,10 +298,10 @@ def test_uuid_mode():
 def test_uuid_and_datetime_mode_together():
     value = [date.today(), uuid.uuid1()]
     dumped = rj.dumps(value,
-                      datetime_mode=rj.DATETIME_MODE_ISO8601,
+                      datetime_mode=rj.DM_ISO8601,
                       uuid_mode=rj.UUID_MODE_CANONICAL)
     loaded = rj.loads(dumped,
-                      datetime_mode=rj.DATETIME_MODE_ISO8601,
+                      datetime_mode=rj.DM_ISO8601,
                       uuid_mode=rj.UUID_MODE_CANONICAL)
     assert loaded == value
 
@@ -368,7 +351,7 @@ def test_uuid_and_datetime_mode_together():
         ('1999-02-03T10:20:30.123456-05:00', datetime),
     ])
 def test_datetime_iso8601(value, cls):
-    result = rj.loads('"%s"' % value, datetime_mode=rj.DATETIME_MODE_ISO8601)
+    result = rj.loads('"%s"' % value, datetime_mode=rj.DM_ISO8601)
     assert isinstance(result, cls)
 
 
@@ -435,9 +418,9 @@ def test_object_hook():
         ( ('[]',), { 'datetime_mode': 'no' } ),
         ( ('[]',), { 'datetime_mode': 1.0 } ),
         ( ('[]',), { 'datetime_mode': -100 } ),
-        ( ('[]',), { 'datetime_mode': rj.DATETIME_MODE_UNIX_TIME + 1 } ),
-        ( ('[]',), { 'datetime_mode': rj.DATETIME_MODE_UNIX_TIME } ),
-        ( ('[]',), { 'datetime_mode': rj.DATETIME_MODE_SHIFT_TO_UTC } ),
+        ( ('[]',), { 'datetime_mode': rj.DM_UNIX_TIME + 1 } ),
+        ( ('[]',), { 'datetime_mode': rj.DM_UNIX_TIME } ),
+        ( ('[]',), { 'datetime_mode': rj.DM_SHIFT_TO_UTC } ),
         ( ('[]',), { 'uuid_mode': 'no' } ),
         ( ('[]',), { 'uuid_mode': 1.0 } ),
         ( ('[]',), { 'uuid_mode': -100 } ),
@@ -462,8 +445,8 @@ def test_invalid_loads_params(posargs, kwargs):
         ( ([],), { 'datetime_mode': 'no' } ),
         ( ([],), { 'datetime_mode': 1.0 } ),
         ( ([],), { 'datetime_mode': -100 } ),
-        ( ([],), { 'datetime_mode': rj.DATETIME_MODE_UNIX_TIME + 1 } ),
-        ( ([],), { 'datetime_mode': rj.DATETIME_MODE_SHIFT_TO_UTC } ),
+        ( ([],), { 'datetime_mode': rj.DM_UNIX_TIME + 1 } ),
+        ( ([],), { 'datetime_mode': rj.DM_SHIFT_TO_UTC } ),
         ( ([],), { 'uuid_mode': 'no' } ),
         ( ([],), { 'uuid_mode': 1.0 } ),
         ( ([],), { 'uuid_mode': -100 } ),

--- a/tests/test_refs_count.py
+++ b/tests/test_refs_count.py
@@ -42,7 +42,7 @@ foo = Foo('foo')
 
 
 NO_OPTION = {}
-DATETIMES = {'datetime_mode': rj.DATETIME_MODE_ISO8601}
+DATETIMES = {'datetime_mode': rj.DM_ISO8601}
 UUIDS = {'uuid_mode': rj.UUID_MODE_CANONICAL}
 FOOS_DUMP = {'default': default}
 FOOS_LOAD = {'object_hook': hook}


### PR DESCRIPTION
This is almost equivalent to my [previous work](https://github.com/lelit/python-rapidjson/tree/unix-timestamps), but **rebased** and _revised_, separating the new functionalities from the [native numbers](https://github.com/lelit/python-rapidjson/commit/60f4d43f3b93a7dee2ddc5b4f38da12150021891) and [global defaults](https://github.com/lelit/python-rapidjson/commit/2b5c4486008153abebdbcf0bfb598cc538856775) enhancements, that will follow.

This introduces **backward incompatibilities** so, if accepted, will land in a new 0.1.0 release.