### PR TITLE
Fix build on clang/macOS

### DIFF
--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -11,6 +11,7 @@
 #include <structmember.h>
 
 #include <algorithm>
+#include <string>
 #include <vector>
 
 #include "rapidjson/reader.h"


### PR DESCRIPTION
From 0.2.0 on, rapidjson doesn't build on macOS anymore:

<details>

```
Collecting python-rapidjson
  Downloading https://pypi.vm.ag/root/pypi/+f/32d/87667066c7fb5/python-rapidjson-0.2.3.tar.gz (169kB)
    100% |████████████████████████████████| 174kB 2.0MB/s
Building wheels for collected packages: python-rapidjson
  Running setup.py bdist_wheel for python-rapidjson ... error
  Complete output from command /Users/hynek/.virtualenvs/tempenv-31fe11562239d/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/private/var/folders/n8/bvhdmjbn4ljc498jpsr3rq6r0000gn/T/pip-build-2k40t9mj/python-rapidjson/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /var/folders/n8/bvhdmjbn4ljc498jpsr3rq6r0000gn/T/tmp0hr89fcjpip-wheel- --python-tag cp36:
  running bdist_wheel
  running build
  running build_ext
  building 'rapidjson' extension
  creating build
  creating build/temp.macosx-10.12-x86_64-3.6
  clang -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/usr/local/opt/openssl/include -I/usr/local/opt/openssl/include -arch x86_64 -Wno-error=unused-command-line-argument -DPYTHON_RAPIDJSON_VERSION=0.2.3 -I./rapidjson/include -I/Users/hynek/.pyenv/versions/3.6.2/include/python3.6m -c ./rapidjson.cpp -o build/temp.macosx-10.12-x86_64-3.6/./rapidjson.o
  ./rapidjson.cpp:555:25: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
              std::string zstr(str, length);
                          ^
  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/iosfwd:193:33: note: template is declared here
      class _LIBCPP_TYPE_VIS_ONLY basic_string;
                                  ^
  ./rapidjson.cpp:1095:50: warning: comparison of constant 4 with expression of type 'ParseMode' is always false [-Wtautological-constant-out-of-range-compare]
              if (parseMode < PM_NONE || parseMode >= 1<<2) {
                                         ~~~~~~~~~ ^  ~~~~
  ./rapidjson.cpp:1119:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"datetime_mode",
       ^
  ./rapidjson.cpp:1120:63: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_UINT, offsetof(DecoderObject, datetimeMode), READONLY, "datetime_mode"},
                                                                ^
  ./rapidjson.cpp:1121:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"uuid_mode",
       ^
  ./rapidjson.cpp:1122:59: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_UINT, offsetof(DecoderObject, uuidMode), READONLY, "uuid_mode"},
                                                            ^
  ./rapidjson.cpp:1123:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"number_mode",
       ^
  ./rapidjson.cpp:1124:61: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_UINT, offsetof(DecoderObject, numberMode), READONLY, "number_mode"},
                                                              ^
  ./rapidjson.cpp:1125:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"parse_mode",
       ^
  ./rapidjson.cpp:1126:60: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_UINT, offsetof(DecoderObject, parseMode), READONLY, "parse_mode"},
                                                             ^
  ./rapidjson.cpp:1413:50: warning: comparison of constant 4 with expression of type 'ParseMode' is always false [-Wtautological-constant-out-of-range-compare]
              if (parseMode < PM_NONE || parseMode >= 1<<2) {
                                         ~~~~~~~~~ ^  ~~~~
  ./rapidjson.cpp:2191:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"skip_invalid_keys",
       ^
  ./rapidjson.cpp:2192:66: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_BOOL, offsetof(EncoderObject, skipInvalidKeys), READONLY, "skip_invalid_keys"},
                                                                   ^
  ./rapidjson.cpp:2193:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"ensure_ascii",
       ^
  ./rapidjson.cpp:2194:62: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_BOOL, offsetof(EncoderObject, ensureAscii), READONLY, "ensure_ascii"},
                                                               ^
  ./rapidjson.cpp:2195:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"indent",
       ^
  ./rapidjson.cpp:2196:57: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_UINT, offsetof(EncoderObject, indent), READONLY, "indent"},
                                                          ^
  ./rapidjson.cpp:2197:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"sort_keys",
       ^
  ./rapidjson.cpp:2198:62: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_BOOL, offsetof(EncoderObject, ensureAscii), READONLY, "sort_keys"},
                                                               ^
  ./rapidjson.cpp:2199:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"max_recursion_depth",
       ^
  ./rapidjson.cpp:2200:68: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_UINT, offsetof(EncoderObject, maxRecursionDepth), READONLY, "max_recursion_depth"},
                                                                     ^
  ./rapidjson.cpp:2201:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"datetime_mode",
       ^
  ./rapidjson.cpp:2202:63: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_UINT, offsetof(EncoderObject, datetimeMode), READONLY, "datetime_mode"},
                                                                ^
  ./rapidjson.cpp:2203:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"uuid_mode",
       ^
  ./rapidjson.cpp:2204:59: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_UINT, offsetof(EncoderObject, uuidMode), READONLY, "uuid_mode"},
                                                            ^
  ./rapidjson.cpp:2205:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
      {"number_mode",
       ^
  ./rapidjson.cpp:2206:61: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
       T_UINT, offsetof(EncoderObject, numberMode), READONLY, "number_mode"},
                                                              ^
  26 warnings and 1 error generated.
  error: command 'clang' failed with exit status 1

  ----------------------------------------
  Failed building wheel for python-rapidjson
  Running setup.py clean for python-rapidjson
Failed to build python-rapidjson
Installing collected packages: python-rapidjson
  Running setup.py install for python-rapidjson ... error
    Complete output from command /Users/hynek/.virtualenvs/tempenv-31fe11562239d/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/private/var/folders/n8/bvhdmjbn4ljc498jpsr3rq6r0000gn/T/pip-build-2k40t9mj/python-rapidjson/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /var/folders/n8/bvhdmjbn4ljc498jpsr3rq6r0000gn/T/pip-od_lyhy7-record/install-record.txt --single-version-externally-managed --compile --install-headers /Users/hynek/.virtualenvs/tempenv-31fe11562239d/include/site/python3.6/python-rapidjson:
    running install
    running build
    running build_ext
    building 'rapidjson' extension
    creating build
    creating build/temp.macosx-10.12-x86_64-3.6
    clang -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/usr/local/opt/openssl/include -I/usr/local/opt/openssl/include -arch x86_64 -Wno-error=unused-command-line-argument -DPYTHON_RAPIDJSON_VERSION=0.2.3 -I./rapidjson/include -I/Users/hynek/.pyenv/versions/3.6.2/include/python3.6m -c ./rapidjson.cpp -o build/temp.macosx-10.12-x86_64-3.6/./rapidjson.o
    ./rapidjson.cpp:555:25: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
                std::string zstr(str, length);
                            ^
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/iosfwd:193:33: note: template is declared here
        class _LIBCPP_TYPE_VIS_ONLY basic_string;
                                    ^
    ./rapidjson.cpp:1095:50: warning: comparison of constant 4 with expression of type 'ParseMode' is always false [-Wtautological-constant-out-of-range-compare]
                if (parseMode < PM_NONE || parseMode >= 1<<2) {
                                           ~~~~~~~~~ ^  ~~~~
    ./rapidjson.cpp:1119:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"datetime_mode",
         ^
    ./rapidjson.cpp:1120:63: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_UINT, offsetof(DecoderObject, datetimeMode), READONLY, "datetime_mode"},
                                                                  ^
    ./rapidjson.cpp:1121:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"uuid_mode",
         ^
    ./rapidjson.cpp:1122:59: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_UINT, offsetof(DecoderObject, uuidMode), READONLY, "uuid_mode"},
                                                              ^
    ./rapidjson.cpp:1123:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"number_mode",
         ^
    ./rapidjson.cpp:1124:61: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_UINT, offsetof(DecoderObject, numberMode), READONLY, "number_mode"},
                                                                ^
    ./rapidjson.cpp:1125:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"parse_mode",
         ^
    ./rapidjson.cpp:1126:60: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_UINT, offsetof(DecoderObject, parseMode), READONLY, "parse_mode"},
                                                               ^
    ./rapidjson.cpp:1413:50: warning: comparison of constant 4 with expression of type 'ParseMode' is always false [-Wtautological-constant-out-of-range-compare]
                if (parseMode < PM_NONE || parseMode >= 1<<2) {
                                           ~~~~~~~~~ ^  ~~~~
    ./rapidjson.cpp:2191:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"skip_invalid_keys",
         ^
    ./rapidjson.cpp:2192:66: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_BOOL, offsetof(EncoderObject, skipInvalidKeys), READONLY, "skip_invalid_keys"},
                                                                     ^
    ./rapidjson.cpp:2193:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"ensure_ascii",
         ^
    ./rapidjson.cpp:2194:62: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_BOOL, offsetof(EncoderObject, ensureAscii), READONLY, "ensure_ascii"},
                                                                 ^
    ./rapidjson.cpp:2195:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"indent",
         ^
    ./rapidjson.cpp:2196:57: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_UINT, offsetof(EncoderObject, indent), READONLY, "indent"},
                                                            ^
    ./rapidjson.cpp:2197:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"sort_keys",
         ^
    ./rapidjson.cpp:2198:62: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_BOOL, offsetof(EncoderObject, ensureAscii), READONLY, "sort_keys"},
                                                                 ^
    ./rapidjson.cpp:2199:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"max_recursion_depth",
         ^
    ./rapidjson.cpp:2200:68: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_UINT, offsetof(EncoderObject, maxRecursionDepth), READONLY, "max_recursion_depth"},
                                                                       ^
    ./rapidjson.cpp:2201:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"datetime_mode",
         ^
    ./rapidjson.cpp:2202:63: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_UINT, offsetof(EncoderObject, datetimeMode), READONLY, "datetime_mode"},
                                                                  ^
    ./rapidjson.cpp:2203:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"uuid_mode",
         ^
    ./rapidjson.cpp:2204:59: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_UINT, offsetof(EncoderObject, uuidMode), READONLY, "uuid_mode"},
                                                              ^
    ./rapidjson.cpp:2205:6: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
        {"number_mode",
         ^
    ./rapidjson.cpp:2206:61: warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
         T_UINT, offsetof(EncoderObject, numberMode), READONLY, "number_mode"},
                                                                ^
    26 warnings and 1 error generated.
    error: command 'clang' failed with exit status 1

    ----------------------------------------
Command "/Users/hynek/.virtualenvs/tempenv-31fe11562239d/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/private/var/folders/n8/bvhdmjbn4ljc498jpsr3rq6r0000gn/T/pip-build-2k40t9mj/python-rapidjson/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /var/folders/n8/bvhdmjbn4ljc498jpsr3rq6r0000gn/T/pi
```

</details>

The problem is a missing include of string.  This PR fixes it.  If it doesn't cause any problems, a hot fix release would be much appreciated. :)