### PR TITLE
Avoid error when whitespace.el is not loaded

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,5 @@
 ((nil . ((fill-column . 90)
          ;; force reinstall of whitespace font-lock customization
-         (eval . (whitespace-color-on))))
+         (eval . (if (functionp 'whitespace-color-on)
+		     (whitespace-color-on)))))
  (c++-mode . ((eval . (c-set-style "stroustrup")))))


### PR DESCRIPTION
whitespace-color-on is not defined when whitespace.el is not loaded and cause following error:
File local-variables error: (void-function whitespace-color-on)