### PR TITLE
Implement the streaming interface

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,6 +16,7 @@
 
    dumps
    loads
+   load
    encoder
    decoder
    validator

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,7 @@
    :maxdepth: 2
 
    dumps
+   dump
    loads
    load
    encoder

--- a/docs/decoder.rst
+++ b/docs/decoder.rst
@@ -13,6 +13,7 @@
 
 .. testsetup::
 
+   import io
    from rapidjson import (Decoder, Encoder, DM_NONE, DM_ISO8601, DM_UNIX_TIME,
                           DM_ONLY_SECONDS, DM_IGNORE_TZ, DM_NAIVE_IS_UTC, DM_SHIFT_TO_UTC,
                           UM_NONE, UM_CANONICAL, UM_HEX, NM_NATIVE, NM_DECIMAL, NM_NAN,
@@ -31,16 +32,19 @@
                           extensions <loads-parse-mode>`
 
 
-   .. method:: __call__(json)
+   .. method:: __call__(json, chunk_size=102400)
 
-      :param json: either a ``str`` instance or an *UTF-8* ``bytes`` instance, containing
-                   the ``JSON`` to be decoded
+      :param json: either a ``str`` instance, an *UTF-8* ``bytes`` instance or a
+                   *file-like* stream, containing the ``JSON`` to be decoded
+      :param int size: in case of a stream, it will be read in chunks of this size
       :returns: a Python value
 
       .. doctest::
 
          >>> decoder = Decoder()
          >>> decoder('"€ 0.50"')
+         '€ 0.50'
+         >>> decoder(io.StringIO('"€ 0.50"'))
          '€ 0.50'
          >>> decoder(b'"\xe2\x82\xac 0.50"')
          '€ 0.50'

--- a/docs/decoder.rst
+++ b/docs/decoder.rst
@@ -32,7 +32,7 @@
                           extensions <loads-parse-mode>`
 
 
-   .. method:: __call__(json, chunk_size=102400)
+   .. method:: __call__(json, chunk_size=65536)
 
       :param json: either a ``str`` instance, an *UTF-8* ``bytes`` instance or a
                    *file-like* stream, containing the ``JSON`` to be decoded

--- a/docs/decoder.rst
+++ b/docs/decoder.rst
@@ -46,6 +46,8 @@
          '€ 0.50'
          >>> decoder(io.StringIO('"€ 0.50"'))
          '€ 0.50'
+         >>> decoder(io.BytesIO(b'"\xe2\x82\xac 0.50"'))
+         '€ 0.50'
          >>> decoder(b'"\xe2\x82\xac 0.50"')
          '€ 0.50'
 

--- a/docs/dump.rst
+++ b/docs/dump.rst
@@ -1,0 +1,63 @@
+.. -*- coding: utf-8 -*-
+.. :Project:   python-rapidjson -- dump function documentation
+.. :Author:    Lele Gaifax <lele@metapensiero.it>
+.. :License:   MIT License
+.. :Copyright: © 2017 Lele Gaifax
+..
+
+=================
+ dump() function
+=================
+
+.. module:: rapidjson
+
+.. testsetup::
+
+   import io
+   from rapidjson import dump
+
+.. function:: dump(obj, stream, *, skipkeys=False, ensure_ascii=True, indent=None, \
+                   default=None, sort_keys=False, number_mode=None, datetime_mode=None, \
+                   uuid_mode=None, chunk_size=65536, allow_nan=True)
+
+   Encode given Python `obj` instance into a ``JSON`` stream.
+
+   :param obj: the value to be serialized
+   :param stream: a *file-like* instance (currently only *binary* streams are implemented)
+   :param bool skipkeys: whether skip invalid :class:`dict` keys
+   :param bool ensure_ascii: whether the output should contain only ASCII
+                             characters (currently only ``ensure_ascii=False``
+                             is implemented)
+   :param int indent: indentation width to produce pretty printed JSON
+   :param callable default: a function that gets called for objects that can't
+                            otherwise be serialized
+   :param bool sort_keys: whether dictionary keys should be sorted
+                          alphabetically
+   :param int number_mode: enable particular behaviors in handling numbers
+   :param int datetime_mode: how should :class:`datetime`, :class:`time` and
+                             :class:`date` instances be handled
+   :param int uuid_mode: how should :class:`UUID` instances be handled
+   :param int chunk_size: write the stream in chunks of this size at a time
+   :param bool allow_nan: *compatibility* flag equivalent to ``number_mode=NM_NAN``
+
+   The function has the same behaviour as :func:`dumps()`, except that it requires
+   an additional mandatory parameter, a *file-like* writable `stream` instance:
+
+   .. doctest::
+
+      >>> stream = io.BytesIO()
+      >>> dump('"bar"', stream, ensure_ascii=False)
+      >>> stream.getvalue()
+      b'"\\"bar\\""'
+
+   Support for text streams is currently **not** implemented:
+
+   .. doctest::
+
+      >>> stream = io.StringIO()
+      >>> dump('"bar"', stream, ensure_ascii=False)
+      Traceback (most recent call last):
+        ...
+      NotImplementedError: Text stream not (yet?) supported
+
+   Consult the :func:`dumps()` documentation for details on all other arguments.

--- a/docs/dump.rst
+++ b/docs/dump.rst
@@ -23,7 +23,7 @@
    Encode given Python `obj` instance into a ``JSON`` stream.
 
    :param obj: the value to be serialized
-   :param stream: a *file-like* instance (currently only *binary* streams are implemented)
+   :param stream: a *file-like* instance
    :param bool skipkeys: whether skip invalid :class:`dict` keys
    :param bool ensure_ascii: whether the output should contain only ASCII
                              characters (currently only ``ensure_ascii=False``
@@ -46,21 +46,20 @@
    .. doctest::
 
       >>> stream = io.BytesIO()
-      >>> dump('"bar"', stream, ensure_ascii=False)
+      >>> dump('bar', stream, ensure_ascii=False)
       >>> stream.getvalue()
-      b'"\\"bar\\""'
+      b'"bar"'
 
-   Support for text streams is currently **not** implemented:
+   The target may also be a text stream\ [#]_:
 
    .. doctest::
 
       >>> stream = io.StringIO()
-      >>> dump('"bar"', stream, ensure_ascii=False)
-      Traceback (most recent call last):
-        ...
-      NotImplementedError: Text stream not (yet?) supported
+      >>> dump('¯\_(ツ)_/¯', stream, ensure_ascii=False)
+      >>> stream.getvalue()
+      '"¯\\\\_(ツ)_/¯"'
 
-   Support for ``ensure_ascii=True`` is **not** implemented as well:
+   Support for ``ensure_ascii=True`` is currently **not** implemented:
 
    .. doctest::
 
@@ -71,3 +70,6 @@
       NotImplementedError: ensure_ascii=True not implemented
 
    Consult the :func:`dumps()` documentation for details on all other arguments.
+
+.. [#] A *text stream* is recognized by checking the presence of an ``encoding`` member
+       attribute on the instance.

--- a/docs/dump.rst
+++ b/docs/dump.rst
@@ -14,7 +14,7 @@
 .. testsetup::
 
    import io
-   from rapidjson import dump
+   from rapidjson import dump, dumps
 
 .. function:: dump(obj, stream, *, skipkeys=False, ensure_ascii=True, indent=None, \
                    default=None, sort_keys=False, number_mode=None, datetime_mode=None, \
@@ -26,8 +26,7 @@
    :param stream: a *file-like* instance
    :param bool skipkeys: whether skip invalid :class:`dict` keys
    :param bool ensure_ascii: whether the output should contain only ASCII
-                             characters (currently only ``ensure_ascii=False``
-                             is implemented)
+                             characters
    :param int indent: indentation width to produce pretty printed JSON
    :param callable default: a function that gets called for objects that can't
                             otherwise be serialized
@@ -46,7 +45,7 @@
    .. doctest::
 
       >>> stream = io.BytesIO()
-      >>> dump('bar', stream, ensure_ascii=False)
+      >>> dump('bar', stream)
       >>> stream.getvalue()
       b'"bar"'
 
@@ -55,19 +54,9 @@
    .. doctest::
 
       >>> stream = io.StringIO()
-      >>> dump('¯\_(ツ)_/¯', stream, ensure_ascii=False)
-      >>> stream.getvalue()
-      '"¯\\\\_(ツ)_/¯"'
-
-   Support for ``ensure_ascii=True`` is currently **not** implemented:
-
-   .. doctest::
-
-      >>> stream = io.StringIO()
-      >>> dump('"bar"', stream)
-      Traceback (most recent call last):
-        ...
-      NotImplementedError: ensure_ascii=True not implemented
+      >>> dump('¯\_(ツ)_/¯', stream)
+      >>> stream.getvalue() == dumps('¯\_(ツ)_/¯')
+      True
 
    Consult the :func:`dumps()` documentation for details on all other arguments.
 

--- a/docs/dump.rst
+++ b/docs/dump.rst
@@ -60,4 +60,14 @@
         ...
       NotImplementedError: Text stream not (yet?) supported
 
+   Support for ``ensure_ascii=True`` is **not** implemented as well:
+
+   .. doctest::
+
+      >>> stream = io.StringIO()
+      >>> dump('"bar"', stream)
+      Traceback (most recent call last):
+        ...
+      NotImplementedError: ensure_ascii=True not implemented
+
    Consult the :func:`dumps()` documentation for details on all other arguments.

--- a/docs/dumps.rst
+++ b/docs/dumps.rst
@@ -18,12 +18,13 @@
                           UM_NONE, UM_CANONICAL, UM_HEX, NM_NATIVE, NM_DECIMAL, NM_NAN,
                           PM_NONE, PM_COMMENTS, PM_TRAILING_COMMAS)
 
-.. function:: dumps(obj, skipkeys=False, ensure_ascii=True, indent=None, \
+.. function:: dumps(obj, *, skipkeys=False, ensure_ascii=True, indent=None, \
                     default=None, sort_keys=False, number_mode=None, datetime_mode=None, \
                     uuid_mode=None, allow_nan=True)
 
    Encode given Python `obj` instance into a ``JSON`` string.
 
+   :param obj: the value to be serialized
    :param bool skipkeys: whether skip invalid :class:`dict` keys
    :param bool ensure_ascii: whether the output should contain only ASCII
                              characters

--- a/docs/encoder.rst
+++ b/docs/encoder.rst
@@ -46,7 +46,8 @@
       :returns: a string with the ``JSON`` encoded `value`, when `stream` is ``None``
 
       When `stream` is specified, the encoded result will be written there, possibly in
-      chunks of `chunk_size` bytes at a time. Also, the return value will be ``None``,
+      chunks of `chunk_size` bytes at a time, and the return value will be ``None``. Also,
+      currently this variant does **not** implement support for ``ensure_ascii=True``.
 
    .. method:: default(value)
 

--- a/docs/encoder.rst
+++ b/docs/encoder.rst
@@ -45,8 +45,7 @@
       :returns: a string with the ``JSON`` encoded `value`, when `stream` is ``None``
 
       When `stream` is specified, the encoded result will be written there, possibly in
-      chunks of `chunk_size` bytes at a time, and the return value will be ``None``. Also,
-      currently this variant does **not** implement support for ``ensure_ascii=True``.
+      chunks of `chunk_size` bytes at a time, and the return value will be ``None``.
 
    .. method:: default(value)
 

--- a/docs/encoder.rst
+++ b/docs/encoder.rst
@@ -40,8 +40,7 @@
    .. method:: __call__(obj, *, stream=None, chunk_size=65536)
 
       :param obj: the value to be encoded
-      :param stream: a *file-like* instance (currently only *binary* streams are
-                     implemented)
+      :param stream: a *file-like* instance
       :param int chunk_size: write the stream in chunks of this size at a time
       :returns: a string with the ``JSON`` encoded `value`, when `stream` is ``None``
 

--- a/docs/encoder.rst
+++ b/docs/encoder.rst
@@ -37,10 +37,16 @@
    :param int uuid_mode: how should :ref:`UUID instances be handled <dumps-uuid-mode>`
 
 
-   .. method:: __call__(value)
+   .. method:: __call__(obj, *, stream=None, chunk_size=65536)
 
-      :param value: the Python value to be encoded
-      :returns: a string with the ``JSON`` encoded `value`
+      :param obj: the value to be encoded
+      :param stream: a *file-like* instance (currently only *binary* streams are
+                     implemented)
+      :param int chunk_size: write the stream in chunks of this size at a time
+      :returns: a string with the ``JSON`` encoded `value`, when `stream` is ``None``
+
+      When `stream` is specified, the encoded result will be written there, possibly in
+      chunks of `chunk_size` bytes at a time. Also, the return value will be ``None``,
 
    .. method:: default(value)
 

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -17,7 +17,7 @@
    from rapidjson import load
 
 .. function:: load(stream, *, object_hook=None, number_mode=None, datetime_mode=None, \
-                   uuid_mode=None, parse_mode=None, chunk_size=102400, allow_nan=True)
+                   uuid_mode=None, parse_mode=None, chunk_size=65536, allow_nan=True)
 
    Decode the given Python file-like `stream` containing a ``JSON`` formatted value
    into Python object.

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -13,7 +13,7 @@
 
 .. testsetup::
 
-   from io import StringIO
+   import io
    from rapidjson import load
 
 .. function:: load(stream, *, object_hook=None, number_mode=None, datetime_mode=None, \
@@ -40,8 +40,9 @@
 
    .. doctest::
 
-      >>> stream = StringIO('["string", {"kind": "object"}, 3.14159]')
-      >>> load(stream)
+      >>> load(io.StringIO('"Naïve"'))
+      'Naïve'
+      >>> load(io.BytesIO(b'["string", {"kind": "object"}, 3.14159]'))
       ['string', {'kind': 'object'}, 3.14159]
 
    Consult the :func:`loads()` documentation for details on all other arguments.

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -1,0 +1,47 @@
+.. -*- coding: utf-8 -*-
+.. :Project:   python-rapidjson -- load function documentation
+.. :Author:    Lele Gaifax <lele@metapensiero.it>
+.. :License:   MIT License
+.. :Copyright: © 2017 Lele Gaifax
+..
+
+=================
+ load() function
+=================
+
+.. module:: rapidjson
+
+.. testsetup::
+
+   from io import StringIO
+   from rapidjson import load
+
+.. function:: load(stream, *, object_hook=None, number_mode=None, datetime_mode=None, \
+                   uuid_mode=None, parse_mode=None, chunk_size=102400, allow_nan=True)
+
+   Decode the given Python file-like `stream` containing a ``JSON`` formatted value
+   into Python object.
+
+   :param stream: a file-like object
+   :param callable object_hook: an optional function that will be called with the result
+                                of any object literal decoded (a :class:`dict`) and should
+                                return the value to use instead of the :class:`dict`
+   :param int number_mode: enable particular behaviors in handling numbers
+   :param int datetime_mode: how should :class:`datetime` and :class:`date` instances be
+                             handled
+   :param int uuid_mode: how should :class:`UUID` instances be handled
+   :param int parse_mode: whether the parser should allow non-standard JSON extensions
+   :param int chunk_size: read the stream in chunks of this size at a time
+   :param bool allow_nan: *compatibility* flag equivalent to ``number_mode=NM_NAN``
+   :returns: An equivalent Python object.
+
+   The function has the same behaviour as :func:`loads()`, except for the kind of the
+   first argument that is expected to be file-like object instead of a string:
+
+   .. doctest::
+
+      >>> stream = StringIO('["string", {"kind": "object"}, 3.14159]')
+      >>> load(stream)
+      ['string', {'kind': 'object'}, 3.14159]
+
+   Consult the :func:`loads()` documentation for details on all other arguments.

--- a/docs/loads.rst
+++ b/docs/loads.rst
@@ -18,13 +18,13 @@
                           UM_NONE, UM_CANONICAL, UM_HEX, NM_NATIVE, NM_DECIMAL, NM_NAN,
                           PM_NONE, PM_COMMENTS, PM_TRAILING_COMMAS)
 
-.. function:: loads(s, object_hook=None, number_mode=None, datetime_mode=None, \
+.. function:: loads(string, *, object_hook=None, number_mode=None, datetime_mode=None, \
                     uuid_mode=None, parse_mode=None, allow_nan=True)
 
-   Decode the given Python string `s` containing a ``JSON`` formatted value
+   Decode the given Python string `string` containing a ``JSON`` formatted value
    into Python object.
 
-   :param str s: The JSON string to parse
+   :param str string: The JSON string to parse
    :param callable object_hook: an optional function that will be called with the result
                                 of any object literal decoded (a :class:`dict`) and should
                                 return the value to use instead of the :class:`dict`

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -3268,7 +3268,7 @@ static PyObject* validator_call(PyObject* self, PyObject* args, PyObject* kwargs
             return NULL;
     }
     else {
-        PyErr_SetString(PyExc_TypeError, "Expected string or utf-8 encoded bytes");
+        PyErr_SetString(PyExc_TypeError, "Expected string or UTF-8 encoded bytes");
         return NULL;
     }
 
@@ -3341,7 +3341,7 @@ static PyObject* validator_new(PyTypeObject* type, PyObject* args, PyObject* kwa
             return NULL;
     }
     else {
-        PyErr_SetString(PyExc_TypeError, "Expected string or utf-8 encoded bytes");
+        PyErr_SetString(PyExc_TypeError, "Expected string or UTF-8 encoded bytes");
         return NULL;
     }
 

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -1547,7 +1547,7 @@ load(PyObject* self, PyObject* args, PyObject* kwargs)
             unsigned long ul = PyLong_AsUnsignedLong(chunkSizeObj);
             if (ul < 4 || ul > UINT_MAX) {
                 PyErr_SetString(PyExc_ValueError,
-                                "Invalid chunk_size, must > 4 and < UINT_MAX");
+                                "Invalid chunk_size, must be between 4 and UINT_MAX");
                 return NULL;
             }
             chunkSize = (size_t) ul;

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -2993,6 +2993,7 @@ do_stream_encode(PyObject* value, PyObject* stream, size_t chunkSize,
 
     if (!prettyPrint) {
         if (ensureAscii) {
+            // FIXME: dunno if it is possible to inject ASCII encoding here
             PyErr_SetString(PyExc_NotImplementedError, "ensure_ascii=True not implemented");
             return NULL;
         }
@@ -3002,6 +3003,7 @@ do_stream_encode(PyObject* value, PyObject* stream, size_t chunkSize,
         }
     }
     else if (ensureAscii) {
+        // FIXME: dunno if it is possible to inject ASCII encoding here
         PyErr_SetString(PyExc_NotImplementedError, "ensure_ascii=True not implemented");
         return NULL;
     }

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -207,6 +207,7 @@ public:
         chunk = NULL;
         chunkLen = 0;
         pos = 0;
+        offset = 0;
         eof = false;
     }
 
@@ -264,7 +265,13 @@ private:
         }
         else {
             Py_ssize_t len;
-            buffer = PyUnicode_AsUTF8AndSize(chunk, &len);
+
+            if (PyBytes_Check(chunk)) {
+                len = PyBytes_GET_SIZE(chunk);
+                buffer = PyBytes_AS_STRING(chunk);
+            }
+            else
+                buffer = PyUnicode_AsUTF8AndSize(chunk, &len);
 
             if (len == 0) {
                 eof = true;
@@ -281,10 +288,10 @@ private:
     PyObject* chunkSize;
     PyObject* chunk;
     Ch* buffer;
-    unsigned int chunkLen;
-    unsigned int pos;
-    bool eof;
+    size_t chunkLen;
+    size_t pos;
     size_t offset;
+    bool eof;
 };
 
 

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -411,6 +411,11 @@ private:
 };
 
 
+inline void PutUnsafe(PyWriteStreamWrapper& stream, char c) {
+    stream.Put(c);
+}
+
+
 /////////////
 // Decoder //
 /////////////
@@ -3020,9 +3025,8 @@ do_stream_encode(PyObject* value, PyObject* stream, size_t chunkSize,
 
     if (!prettyPrint) {
         if (ensureAscii) {
-            // FIXME: dunno if it is possible to inject ASCII encoding here
-            PyErr_SetString(PyExc_NotImplementedError, "ensure_ascii=True not implemented");
-            return NULL;
+            Writer<PyWriteStreamWrapper, UTF8<>, ASCII<> > writer(os);
+            return DUMP_INTERNAL_CALL;
         }
         else {
             Writer<PyWriteStreamWrapper> writer(os);
@@ -3030,9 +3034,9 @@ do_stream_encode(PyObject* value, PyObject* stream, size_t chunkSize,
         }
     }
     else if (ensureAscii) {
-        // FIXME: dunno if it is possible to inject ASCII encoding here
-        PyErr_SetString(PyExc_NotImplementedError, "ensure_ascii=True not implemented");
-        return NULL;
+        PrettyWriter<PyWriteStreamWrapper, UTF8<>, ASCII<> > writer(os);
+        writer.SetIndent(' ', indent);
+        return DUMP_INTERNAL_CALL;
     }
     else {
         PrettyWriter<PyWriteStreamWrapper> writer(os);

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -1549,13 +1549,14 @@ load(PyObject* self, PyObject* args, PyObject* kwargs)
 
     if (chunkSizeObj && chunkSizeObj != Py_None) {
         if (PyLong_Check(chunkSizeObj)) {
-            unsigned long ul = PyLong_AsUnsignedLong(chunkSizeObj);
-            if (ul < 4 || ul > UINT_MAX) {
+            Py_ssize_t size = PyNumber_AsSsize_t(chunkSizeObj, PyExc_ValueError);
+            if (PyErr_Occurred() || size < 4 || size > UINT_MAX) {
                 PyErr_SetString(PyExc_ValueError,
-                                "Invalid chunk_size, must be between 4 and UINT_MAX");
+                                "Invalid chunk_size, must be an integer between 4 and"
+                                " UINT_MAX");
                 return NULL;
             }
-            chunkSize = (size_t) ul;
+            chunkSize = (size_t) size;
         }
         else {
             PyErr_SetString(PyExc_TypeError,
@@ -1831,12 +1832,14 @@ decoder_call(PyObject* self, PyObject* args, PyObject* kwargs)
 
     if (chunkSizeObj && chunkSizeObj != Py_None) {
         if (PyLong_Check(chunkSizeObj)) {
-            unsigned long ul = PyLong_AsUnsignedLong(chunkSizeObj);
-            if (ul == 0 || ul > UINT_MAX) {
-                PyErr_SetString(PyExc_ValueError, "Out of range chunk_size");
+            Py_ssize_t size = PyNumber_AsSsize_t(chunkSizeObj, PyExc_ValueError);
+            if (PyErr_Occurred() || size < 4 || size > UINT_MAX) {
+                PyErr_SetString(PyExc_ValueError,
+                                "Invalid chunk_size, must be an integer between 4 and"
+                                " UINT_MAX");
                 return NULL;
             }
-            chunkSize = (size_t) ul;
+            chunkSize = (size_t) size;
         }
         else {
             PyErr_SetString(PyExc_TypeError,
@@ -2865,12 +2868,14 @@ dump(PyObject* self, PyObject* args, PyObject* kwargs)
 
     if (chunkSizeObj && chunkSizeObj != Py_None) {
         if (PyLong_Check(chunkSizeObj)) {
-            unsigned long ul = PyLong_AsUnsignedLong(chunkSizeObj);
-            if (ul == 0 || ul > UINT_MAX) {
-                PyErr_SetString(PyExc_ValueError, "Out of range chunk_size");
+            Py_ssize_t size = PyNumber_AsSsize_t(chunkSizeObj, PyExc_ValueError);
+            if (PyErr_Occurred() || size < 4 || size > UINT_MAX) {
+                PyErr_SetString(PyExc_ValueError,
+                                "Invalid chunk_size, must be an integer between 4 and"
+                                " UINT_MAX");
                 return NULL;
             }
-            chunkSize = (size_t) ul;
+            chunkSize = (size_t) size;
         }
         else {
             PyErr_SetString(PyExc_TypeError,
@@ -3081,12 +3086,14 @@ encoder_call(PyObject* self, PyObject* args, PyObject* kwargs)
         }
         if (chunkSizeObj && chunkSizeObj != Py_None) {
             if (PyLong_Check(chunkSizeObj)) {
-                unsigned long ul = PyLong_AsUnsignedLong(chunkSizeObj);
-                if (ul == 0 || ul > UINT_MAX) {
-                    PyErr_SetString(PyExc_ValueError, "Out of range chunk_size");
+                Py_ssize_t size = PyNumber_AsSsize_t(chunkSizeObj, PyExc_ValueError);
+                if (PyErr_Occurred() || size < 4 || size > UINT_MAX) {
+                    PyErr_SetString(PyExc_ValueError,
+                                    "Invalid chunk_size, must be an integer between 4 and"
+                                    " UINT_MAX");
                     return NULL;
                 }
-                chunkSize = (size_t) ul;
+                chunkSize = (size_t) size;
             }
             else {
                 PyErr_SetString(PyExc_TypeError,

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -31,7 +31,7 @@ using namespace rapidjson;
 #ifndef Py_SETREF
 #define Py_SETREF(op, op2)                      \
     do {                                        \
-        PyObject *_py_tmp = (PyObject *)(op);   \
+        PyObject* _py_tmp = (PyObject*)(op);    \
         (op) = (op2);                           \
         Py_DECREF(_py_tmp);                     \
     } while (0)
@@ -1143,7 +1143,7 @@ loads(PyObject* self, PyObject* args, PyObject* kwargs)
     int allowNan = -1;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$OOOOOp:rapidjson.loads",
-                                     (char **) kwlist,
+                                     (char**) kwlist,
                                      &jsonObject,
                                      &objectHook,
                                      &numberModeObj,
@@ -1310,7 +1310,7 @@ load(PyObject* self, PyObject* args, PyObject* kwargs)
     int allowNan = -1;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$OOOOOOp:rapidjson.load",
-                                     (char **) kwlist,
+                                     (char**) kwlist,
                                      &jsonObject,
                                      &objectHook,
                                      &numberModeObj,
@@ -1673,7 +1673,7 @@ decoder_call(PyObject* self, PyObject* args, PyObject* kwargs)
     size_t chunkSize = 102400;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$O",
-                                     (char **) kwlist,
+                                     (char**) kwlist,
                                      &jsonObject,
                                      &chunkSizeObj))
         return NULL;
@@ -1744,7 +1744,7 @@ decoder_new(PyTypeObject* type, PyObject* args, PyObject* kwargs)
     };
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|OOOO:Decoder",
-                                     (char **) kwlist,
+                                     (char**) kwlist,
                                      &numberModeObj,
                                      &datetimeModeObj,
                                      &uuidModeObj,
@@ -2513,7 +2513,7 @@ dumps(PyObject* self, PyObject* args, PyObject* kwargs)
     };
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|ppOOpOOOp:rapidjson.dumps",
-                                     (char **) kwlist,
+                                     (char**) kwlist,
                                      &value,
                                      &skipKeys,
                                      &ensureAscii,
@@ -2761,7 +2761,7 @@ encoder_new(PyTypeObject* type, PyObject* args, PyObject* kwargs)
     };
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|ppOpOOO:Encoder",
-                                     (char **) kwlist,
+                                     (char**) kwlist,
                                      &skipInvalidKeys,
                                      &ensureAscii,
                                      &indent,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@
 # :Copyright: © 2016, 2017 Lele Gaifax
 #
 
+import io
 import rapidjson as rj
 
 
@@ -12,10 +13,23 @@ def pytest_generate_tests(metafunc):
     if 'dumps' in metafunc.fixturenames and 'loads' in metafunc.fixturenames:
         metafunc.parametrize('dumps,loads', (
             ((rj.dumps, rj.loads),
-            (lambda o,**opts: rj.Encoder(**opts)(o), lambda j,**opts: rj.Decoder(**opts)(j)))))
+             (lambda o,**opts: rj.Encoder(**opts)(o),
+              lambda j,**opts: rj.Decoder(**opts)(j)))
+        ), ids=('func[string]',
+                'class[string]'))
     elif 'dumps' in metafunc.fixturenames:
         metafunc.parametrize('dumps', (
-            rj.dumps, lambda o,**opts: rj.Encoder(**opts)(o)))
+            rj.dumps,
+            lambda o,**opts: rj.Encoder(**opts)(o)
+        ), ids=('func[string]',
+                'class[string]'))
     elif 'loads' in metafunc.fixturenames:
         metafunc.parametrize('loads', (
-            rj.loads, lambda j,**opts: rj.Decoder(**opts)(j)))
+            rj.loads,
+            lambda j,**opts: rj.load(io.StringIO(j), **opts),
+            lambda j,**opts: rj.Decoder(**opts)(j),
+            lambda j,**opts: rj.Decoder(**opts)(io.StringIO(j)),
+        ), ids=('func[string]',
+                'func[stream]',
+                'class[string]',
+                'class[stream]'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,11 @@ def pytest_generate_tests(metafunc):
     elif 'loads' in metafunc.fixturenames:
         metafunc.parametrize('loads', (
             rj.loads,
-            lambda j,**opts: rj.load(io.StringIO(j), **opts),
+            lambda j,**opts: rj.load(io.BytesIO(j.encode('utf-8')
+                                           if isinstance(j, str) else j), **opts),
             lambda j,**opts: rj.Decoder(**opts)(j),
-            lambda j,**opts: rj.Decoder(**opts)(io.StringIO(j)),
+            lambda j,**opts: rj.Decoder(**opts)(io.BytesIO(j.encode('utf-8')
+                                                      if isinstance(j, str) else j)),
         ), ids=('func[string]',
                 'func[stream]',
                 'class[string]',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,18 @@ import io
 import rapidjson as rj
 
 
+def streaming_dumps(o, **opts):
+    stream = io.BytesIO()
+    rj.dump(o, stream, ensure_ascii=False, **opts)
+    return stream.getvalue().decode('utf-8')
+
+
+def streaming_encoder(o, **opts):
+    stream = io.BytesIO()
+    rj.Encoder(ensure_ascii=False, **opts)(o, stream=stream)
+    return stream.getvalue().decode('utf-8')
+
+
 def pytest_generate_tests(metafunc):
     if 'dumps' in metafunc.fixturenames and 'loads' in metafunc.fixturenames:
         metafunc.parametrize('dumps,loads', (
@@ -20,9 +32,13 @@ def pytest_generate_tests(metafunc):
     elif 'dumps' in metafunc.fixturenames:
         metafunc.parametrize('dumps', (
             rj.dumps,
-            lambda o,**opts: rj.Encoder(**opts)(o)
+            streaming_dumps,
+            lambda o,**opts: rj.Encoder(**opts)(o),
+            streaming_encoder
         ), ids=('func[string]',
-                'class[string]'))
+                'func[stream]',
+                'class[string]',
+                'class[stream]'))
     elif 'loads' in metafunc.fixturenames:
         metafunc.parametrize('loads', (
             rj.loads,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,13 +11,13 @@ import rapidjson as rj
 
 def streaming_dumps(o, **opts):
     stream = io.BytesIO()
-    rj.dump(o, stream, ensure_ascii=False, **opts)
+    rj.dump(o, stream, **opts)
     return stream.getvalue().decode('utf-8')
 
 
 def streaming_encoder(o, **opts):
     stream = io.BytesIO()
-    rj.Encoder(ensure_ascii=False, **opts)(o, stream=stream)
+    rj.Encoder(**opts)(o, stream=stream)
     return stream.getvalue().decode('utf-8')
 
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -44,7 +44,9 @@ def test_skip_invalid_keys():
 
 
 @pytest.mark.unit
-def test_ensure_ascii(dumps):
+def test_ensure_ascii(request, dumps):
+    if '[stream]' in request.node.name:
+        pytest.xfail('streaming interface does is not implemented for ensure_ascii=True')
     s = '\N{GREEK SMALL LETTER ALPHA}\N{GREEK CAPITAL LETTER OMEGA}'
     assert dumps(s) == '"\\u03B1\\u03A9"'
     assert dumps(s, ensure_ascii=True) == '"\\u03B1\\u03A9"'

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -551,14 +551,6 @@ def test_invalid_dumps_params(posargs, kwargs, dumps):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize('cs', (-1, 0, 100**100, 1.23, 'foo'))
-def test_invalid_chunk_size(cs):
-    s = io.StringIO('"foo"')
-    with pytest.raises((ValueError, TypeError)):
-        rj.load(s, chunk_size=cs)
-
-
-@pytest.mark.unit
 def test_explicit_defaults_loads():
     assert rj.loads(
         string='"foo"',
@@ -599,3 +591,22 @@ def test_explicit_defaults_dumps():
         uuid_mode=None,
         allow_nan=True,
     ) == '"foo"'
+
+
+@pytest.mark.unit
+def test_explicit_defaults_dump():
+    stream = io.StringIO()
+    assert rj.dump(
+        obj='foo',
+        stream=stream,
+        skipkeys=False,
+        ensure_ascii=True,
+        indent=None,
+        default=None,
+        sort_keys=False,
+        number_mode=None,
+        datetime_mode=None,
+        uuid_mode=None,
+        allow_nan=True,
+        chunk_size=None) is None
+    assert stream.getvalue() == '"foo"'

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -8,6 +8,7 @@
 
 from calendar import timegm
 from datetime import date, datetime, time
+import io
 import math
 import uuid
 
@@ -550,14 +551,36 @@ def test_invalid_dumps_params(posargs, kwargs, dumps):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize('cs', (-1, 0, 100**100, 1.23, 'foo'))
+def test_invalid_chunk_size(cs):
+    s = io.StringIO('"foo"')
+    with pytest.raises((ValueError, TypeError)):
+        rj.load(s, chunk_size=cs)
+
+
+@pytest.mark.unit
 def test_explicit_defaults_loads():
     assert rj.loads(
-        s='"foo"',
+        string='"foo"',
         object_hook=None,
         number_mode=None,
         datetime_mode=None,
         uuid_mode=None,
         parse_mode=None,
+        allow_nan=True,
+    ) == "foo"
+
+
+@pytest.mark.unit
+def test_explicit_defaults_load():
+    assert rj.load(
+        stream=io.StringIO('"foo"'),
+        object_hook=None,
+        number_mode=None,
+        datetime_mode=None,
+        uuid_mode=None,
+        parse_mode=None,
+        chunk_size=None,
         allow_nan=True,
     ) == "foo"
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -44,9 +44,7 @@ def test_skip_invalid_keys():
 
 
 @pytest.mark.unit
-def test_ensure_ascii(request, dumps):
-    if '[stream]' in request.node.name:
-        pytest.xfail('streaming interface does is not implemented for ensure_ascii=True')
+def test_ensure_ascii(dumps):
     s = '\N{GREEK SMALL LETTER ALPHA}\N{GREEK CAPITAL LETTER OMEGA}'
     assert dumps(s) == '"\\u03B1\\u03A9"'
     assert dumps(s, ensure_ascii=True) == '"\\u03B1\\u03A9"'

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# :Project:   python-rapidjson -- Streaming API related tests
+# :Author:    Lele Gaifax <lele@metapensiero.it>
+# :License:   MIT License
+# :Copyright: © 2017 Lele Gaifax
+#
+
+import io
+import sys
+
+import pytest
+
+import rapidjson as rj
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('cs', (-1, 0, sys.maxsize, 1.23, 'foo'))
+def test_invalid_chunk_size(cs):
+    s = io.StringIO('"foo"')
+    with pytest.raises((ValueError, TypeError)):
+        rj.load(s, chunk_size=cs)
+
+
+class ChunkedStream(io.StringIO):
+    def __init__(self):
+        super().__init__()
+        self.chunks = []
+
+    def write(self, s):
+        super().write(s)
+        self.chunks.append(s)
+
+
+@pytest.mark.unit
+def test_chunked_stream():
+    stream = ChunkedStream()
+    rj.dump('1234567890', stream)
+    assert len(stream.chunks) == 1
+
+    stream = ChunkedStream()
+    rj.dump('1234567890', stream, chunk_size=4)
+    assert len(stream.chunks) == 3
+    assert stream.chunks == ['"123', '4567', '890"']
+
+    stream = ChunkedStream()
+    rj.dump('~𓆙~', stream, ensure_ascii=False, chunk_size=4)
+    assert len(stream.chunks) == 3
+    assert stream.chunks == ['"~', '𓆙', '~"']
+
+    stream = ChunkedStream()
+    rj.dump('~𓆙~', stream, chunk_size=4)
+    assert len(stream.chunks) == 4
+    assert stream.chunks == ['"~\\u', 'D80C', '\\uDD', '99~"']

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -51,3 +51,29 @@ def test_chunked_stream():
     rj.dump('~𓆙~', stream, chunk_size=4)
     assert len(stream.chunks) == 4
     assert stream.chunks == ['"~\\u', 'D80C', '\\uDD', '99~"']
+
+
+class CattyError(RuntimeError):
+    pass
+
+
+class CattyStream(io.StringIO):
+    def read(self, *args, **kwargs):
+        raise CattyError('No real reason')
+
+    def write(self, *args, **kwargs):
+        raise CattyError('No real reason')
+
+
+@pytest.mark.unit
+def test_underlying_stream_read_error():
+    stream = CattyStream()
+    with pytest.raises(CattyError):
+        rj.load(stream)
+
+
+@pytest.mark.unit
+def test_underlying_stream_write_error():
+    stream = CattyStream()
+    with pytest.raises(CattyError):
+        rj.dump('1234567890', stream)

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -14,7 +14,7 @@ import rapidjson as rj
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize('cs', (-1, 0, sys.maxsize, 1.23, 'foo'))
+@pytest.mark.parametrize('cs', (-1, 0, sys.maxsize*10, 1.23, 'foo'))
 def test_invalid_chunk_size(cs):
     s = io.StringIO('"foo"')
     with pytest.raises((ValueError, TypeError)):

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -59,30 +59,3 @@ def test_load_surrogate(j, loads):
 def test_unicode_decode_error(j, loads):
     with pytest.raises(UnicodeDecodeError, match="'utf-8' codec can't decode byte"):
         loads(j)
-
-
-class ChunkedStream(io.StringIO):
-    def __init__(self):
-        super().__init__()
-        self.chunks = []
-
-    def write(self, s):
-        super().write(s)
-        self.chunks.append(s)
-
-
-@pytest.mark.unit
-def test_chunked_stream():
-    stream = ChunkedStream()
-    rapidjson.dump('1234567890', stream, ensure_ascii=False)
-    assert len(stream.chunks) == 1
-
-    stream = ChunkedStream()
-    rapidjson.dump('1234567890', stream, ensure_ascii=False, chunk_size=4)
-    assert len(stream.chunks) == 3
-    assert stream.chunks == ['"123', '4567', '890"']
-
-    stream = ChunkedStream()
-    rapidjson.dump('~𓆙~', stream, ensure_ascii=False, chunk_size=4)
-    assert len(stream.chunks) == 3
-    assert stream.chunks == ['"~', '𓆙', '~"']


### PR DESCRIPTION
This is a possible solution for issue #80.

I'm not sure I will merge this request, due to its major glitch: currently exceptions raised by the underlying Python streams are ignored, because I could not figure out a way to handle them in the RapidJSON layer.

Anyway, this at least will run the tests on other platforms.