### PR TITLE
Allow injection of preserialized JSON using the `default` API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
       # Note: TWINE_PASSWORD is set in Travis settings
 
 install:
-  - if [ $TRAVIS_OS_NAME = osx ]; then brew install python3; fi
+  - if [ $TRAVIS_OS_NAME = osx ]; then brew upgrade python; fi
   - pip3 install -r requirements-test.txt
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - pip3 install -r requirements-test.txt
 
 script:
-  - pip3 install . && pytest tests
+  - pip3 install . && pytest tests && cd docs; make doctest; cd -
   - |
     pip3 install cibuildwheel==0.6.0
     cibuildwheel --output-dir wheelhouse

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,6 +21,7 @@
    encoder
    decoder
    validator
+   rawjson
 
 .. data:: __author__
 

--- a/docs/encoder.rst
+++ b/docs/encoder.rst
@@ -54,9 +54,8 @@
       :returns: a *JSON-serializable* value
 
       If implemented, this method is called whenever the serialization machinery finds a
-      Python object that it does not recognize: if possible, the method should returns either a
-      *JSON encodable* version of the `value` or an already encoded bytes object that will be used
-      verbatim, whitespace included:
+      Python object that it does not recognize: if possible, the method should returns a
+      *JSON encodable* version of the `value`, otherwise raise a :exc:`TypeError`:
 
       .. doctest::
 
@@ -80,13 +79,3 @@
          >>> pe = PointEncoder(sort_keys=True)
          >>> pe(point)
          '{"x":1,"y":2}'
-         >>> class PreserializingPointEncoder(Encoder):
-         ...   def default(self, obj):
-         ...     if isinstance(obj, Point):
-         ...       return f'{{"x": {obj.x}, "y": {obj.y}}}'.encode()
-         ...     else:
-         ...       raise ValueError('%r is not JSON serializable' % obj)
-         ...
-         >>> pe = PreserializingPointEncoder(sort_keys=True)
-         >>> pe(point)
-         '{"x": 1, "y": 2}'

--- a/docs/encoder.rst
+++ b/docs/encoder.rst
@@ -54,8 +54,9 @@
       :returns: a *JSON-serializable* value
 
       If implemented, this method is called whenever the serialization machinery finds a
-      Python object that it does not recognize: if possible, the method should returns a
-      *JSON encodable* version of the `value`, otherwise raise a :exc:`TypeError`:
+      Python object that it does not recognize: if possible, the method should returns either a
+      *JSON encodable* version of the `value` or an already encoded bytes object that will be used
+      verbatim, whitespace included:
 
       .. doctest::
 
@@ -79,3 +80,13 @@
          >>> pe = PointEncoder(sort_keys=True)
          >>> pe(point)
          '{"x":1,"y":2}'
+         >>> class PreserializingPointEncoder(Encoder):
+         ...   def default(self, obj):
+         ...     if isinstance(obj, Point):
+         ...       return f'{{"x": {obj.x}, "y": {obj.y}}}'.encode()
+         ...     else:
+         ...       raise ValueError('%r is not JSON serializable' % obj)
+         ...
+         >>> pe = PreserializingPointEncoder(sort_keys=True)
+         >>> pe(point)
+         '{"x": 1, "y": 2}'

--- a/docs/rawjson.rst
+++ b/docs/rawjson.rst
@@ -10,25 +10,35 @@
  RawJSON class
 ===============
 
-A possible use case is mixing preserialized objects with regular ones.
+.. module:: rapidjson
 
-For instance, you might want to store preserialized records in your database,
-and then be able to use rapidjson to pack them in a serialized list.
+.. testsetup::
 
-The RawJSON class serves this purpose.
+   from rapidjson import RawJSON, dumps
 
-It must be instantiated with a bytestring:
+.. class:: RawJSON(value)
+
+   Preserialized JSON string.
+
+   :param str value: The string that rapidjson should use verbatim when serializing this object
+
+Some applications might decide to store JSON-serialized objects in their database,
+but might need to assemble them in a bigger JSON.
+
+The RawJSON class serves this purpose. When serialized, the string value provided will be used verbatim,
+whitespace included.
 
       .. doctest::
 
-        >>> import rapidjson
-        >>> raw_list = rapidjson.RawJSON('[1, 2,3]')
-        >>> rapidjson.dumps({'foo': raw_list})
+        >>> raw_list = RawJSON('[1, 2,3]')
+        >>> dumps({'foo': raw_list})
         '{"foo":[1, 2,3]}'
 
 Rapidjson runs no checks on the preserialized data. This means that it can
-potentially output invalid JSON, if you provide it.
-        >>> import rapidjson
-        >>> raw_list = rapidjson.RawJSON('[1, ')
-        >>> rapidjson.dumps({'foo': raw_list})
+potentially output invalid JSON, if you provide it:
+
+      .. doctest::
+
+        >>> raw_list = RawJSON('[1, ')
+        >>> dumps({'foo': raw_list})
         '{"foo":[1, }'

--- a/docs/rawjson.rst
+++ b/docs/rawjson.rst
@@ -22,6 +22,6 @@ It must be instantiated with a bytestring:
       .. doctest::
 
         >>> import rapidjson
-        >>> raw_list = rapidjson.RawJSON(b'[1, 2,3]')
+        >>> raw_list = rapidjson.RawJSON('[1, 2,3]')
         >>> rapidjson.dumps({'foo': raw_list})
         '{"foo":[1, 2,3]}'

--- a/docs/rawjson.rst
+++ b/docs/rawjson.rst
@@ -25,3 +25,10 @@ It must be instantiated with a bytestring:
         >>> raw_list = rapidjson.RawJSON('[1, 2,3]')
         >>> rapidjson.dumps({'foo': raw_list})
         '{"foo":[1, 2,3]}'
+
+Rapidjson runs no checks on the preserialized data. This means that it can
+potentially output invalid JSON, if you provide it.
+        >>> import rapidjson
+        >>> raw_list = rapidjson.RawJSON('[1, ')
+        >>> rapidjson.dumps({'foo': raw_list})
+        '{"foo":[1, }'

--- a/docs/rawjson.rst
+++ b/docs/rawjson.rst
@@ -1,0 +1,27 @@
+.. -*- coding: utf-8 -*-
+.. :Project:   python-rapidjson -- RawJSON class documentation
+.. :Author:    Silvio Tomatis <silviot@gmail.com>
+.. :License:   MIT License
+.. :Copyright: © 2018 Silvio Tomatis
+.. :Copyright: © 2018 Lele Gaifax
+..
+
+===============
+ RawJSON class
+===============
+
+A possible use case is mixing preserialized objects with regular ones.
+
+For instance, you might want to store preserialized records in your database,
+and then be able to use rapidjson to pack them in a serialized list.
+
+The RawJSON class serves this purpose.
+
+It must be instantiated with a bytestring:
+
+      .. doctest::
+
+        >>> import rapidjson
+        >>> raw_list = rapidjson.RawJSON(b'[1, 2,3]')
+        >>> rapidjson.dumps({'foo': raw_list})
+        '{"foo":[1, 2,3]}'

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -471,7 +471,7 @@ PyDoc_STRVAR(rawjson_doc,
              "\n"
              "When rapidjson tries to serialize objects of this class, it will"
              " use their literal `value`. For instance:\n"
-             ">>> rapidjson.dumps(RawJSON(b'{\"already\": \"serialized\"}'))\n"
+             ">>> rapidjson.dumps(RawJSON('{\"already\": \"serialized\"}'))\n"
              "'{\"already\": \"serialized\"}'");
 
 static PyTypeObject RawJSON_Type = {

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -416,6 +416,107 @@ inline void PutUnsafe(PyWriteStreamWrapper& stream, char c) {
 
 
 /////////////
+// RawJSON //
+/////////////
+
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *value;
+} RawJSON;
+
+static void
+RawJSON_dealloc(RawJSON* self)
+{
+    Py_XDECREF(self->value);
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+
+static int
+RawJSON_init(RawJSON *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *value=NULL, *tmp;
+
+    static char *kwlist[] = {"value", NULL};
+
+    if (! PyArg_ParseTupleAndKeywords(args, kwds, "S", kwlist,
+                                      &value))
+        return -1;
+
+    if (!PyBytes_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "Only byte strings allowed");
+        return NULL;
+    }
+
+    if (value) {
+        tmp = self->value;
+        Py_INCREF(value);
+        self->value = value;
+        Py_XDECREF(tmp);
+    }
+
+    return 0;
+}
+
+static PyMemberDef RawJSON_members[] = {
+    {"value", T_OBJECT_EX, offsetof(RawJSON, value), 0,
+     "Byte string representing a serialized JSON object"},
+    {NULL}  /* Sentinel */
+};
+
+
+PyDoc_STRVAR(rawjson_doc,
+             "Raw (preserialized) JSON objects\n"
+             "\n"
+             "When rapidjson tries to serialize objects of this class, it will"
+             " use their literal `value`. For instance:\n"
+             ">>> rapidjson.dumps(RawJSON(b'{\"already\": \"serialized\"}'))\n"
+             "'{\"already\": \"serialized\"}'");
+
+static PyTypeObject RawJSON_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "rapidjson.RawJSON",            /* tp_name */
+    sizeof(RawJSON),                /* tp_basicsize */
+    0,                              /* tp_itemsize */
+    (destructor)RawJSON_dealloc,    /* tp_dealloc */
+    0,                              /* tp_print */
+    0,                              /* tp_getattr */
+    0,                              /* tp_setattr */
+    0,                              /* tp_compare */
+    0,                              /* tp_repr */
+    0,                              /* tp_as_number */
+    0,                              /* tp_as_sequence */
+    0,                              /* tp_as_mapping */
+    0,                              /* tp_hash */
+    0,                              /* tp_call */
+    0,                              /* tp_str */
+    0,                              /* tp_getattro */
+    0,                              /* tp_setattro */
+    0,                              /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,             /* tp_flags */
+    rawjson_doc,                    /* tp_doc */
+    0,                              /* tp_traverse */
+    0,                              /* tp_clear */
+    0,                              /* tp_richcompare */
+    0,                              /* tp_weaklistoffset */
+    0,                              /* tp_iter */
+    0,                              /* tp_iternext */
+    0,                              /* tp_methods */
+    RawJSON_members,                /* tp_members */
+    0,                              /* tp_getset */
+    0,                              /* tp_base */
+    0,                              /* tp_dict */
+    0,                              /* tp_descr_get */
+    0,                              /* tp_descr_set */
+    0,                              /* tp_dictoffset */
+    (initproc)RawJSON_init,         /* tp_init */
+    0,                              /* tp_alloc */
+    PyType_GenericNew,              /* tp_new */
+};
+
+
+/////////////
 // Decoder //
 /////////////
 
@@ -3694,6 +3795,12 @@ PyInit_rapidjson()
 
     Py_INCREF(&Validator_Type);
     PyModule_AddObject(m, "Validator", (PyObject*) &Validator_Type);
+
+    RawJSON_Type.tp_new = PyType_GenericNew;
+    if (PyType_Ready(&RawJSON_Type) < 0)
+        return NULL;
+    Py_INCREF(&RawJSON_Type);
+    PyModule_AddObject(m, "RawJSON", (PyObject *)&RawJSON_Type);
 
     return m;
 

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -2724,28 +2724,25 @@ dumps_internal(
 
         writer->EndArray();
     }
+    else if PyObject_TypeCheck(object, &RawJSON_Type) {
+        Py_ssize_t l = PyBytes_Size(((RawJSON*)object)->value);
+        ASSERT_VALID_SIZE(l);
+        const char* s = PyBytes_AsString(((RawJSON*)object)->value);
+        writer->RawValue(s, (SizeType) l, kStringType);
+    }
     else if (defaultFn) {
         PyObject* retval = PyObject_CallFunctionObjArgs(defaultFn, object, NULL);
         if (retval == NULL)
             return false;
-        if (PyBytes_Check(retval)) {
-            Py_ssize_t l = PyBytes_Size(retval);
-            ASSERT_VALID_SIZE(l);
-            const char* s = PyBytes_AsString(retval);
-            writer->RawValue(s, (SizeType) l, kStringType);
+        if (Py_EnterRecursiveCall(" while JSONifying default function result")) {
             Py_DECREF(retval);
+            return false;
         }
-        else {
-            if (Py_EnterRecursiveCall(" while JSONifying default function result")) {
-                Py_DECREF(retval);
-                return false;
-            }
-            bool r = RECURSE(retval);
-            Py_LeaveRecursiveCall();
-            Py_DECREF(retval);
-            if (!r)
-                return false;
-        }
+        bool r = RECURSE(retval);
+        Py_LeaveRecursiveCall();
+        Py_DECREF(retval);
+        if (!r)
+            return false;
     }
     else {
         PyErr_Format(PyExc_TypeError, "%R is not JSON serializable", object);

--- a/tests/test_rawjson.py
+++ b/tests/test_rawjson.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# :Project:   python-rapidjson -- Tests on RawJSON
+# :Author:    Silvio Tomatis <silviot@gmail.com>
+# :License:   MIT License
+# :Copyright: © 2018 Silvio Tomatis
+# :Copyright: © 2018 Lele Gaifax
+#
+
+import pytest
+
+import rapidjson as rj
+
+
+@pytest.mark.unit
+def test_instantiation_positional():
+    value = b'a bytes string'
+    raw = rj.RawJSON(value)
+    assert raw.value == b'a bytes string'
+
+
+@pytest.mark.unit
+def test_instantiation_named():
+    value = b'a bytes string'
+    raw = rj.RawJSON(value=value)
+    assert raw.value == b'a bytes string'
+
+
+@pytest.mark.unit
+def test_only_bytes_allowed():
+    with pytest.raises(TypeError):
+        rj.RawJSON('not a bytes string')
+    with pytest.raises(TypeError):
+        rj.RawJSON({})
+    with pytest.raises(TypeError):
+        rj.RawJSON(None)

--- a/tests/test_rawjson.py
+++ b/tests/test_rawjson.py
@@ -33,3 +33,7 @@ def test_only_bytes_allowed():
         rj.RawJSON({})
     with pytest.raises(TypeError):
         rj.RawJSON(None)
+
+
+def test_mix_preserialized():
+    assert rj.dumps({'a': rj.RawJSON(b'{1 : 2}')}) == '{"a":{1 : 2}}'

--- a/tests/test_rawjson.py
+++ b/tests/test_rawjson.py
@@ -13,22 +13,22 @@ import rapidjson as rj
 
 @pytest.mark.unit
 def test_instantiation_positional():
-    value = b'a bytes string'
+    value = 'a string'
     raw = rj.RawJSON(value)
-    assert raw.value == b'a bytes string'
+    assert raw.value == value
 
 
 @pytest.mark.unit
 def test_instantiation_named():
-    value = b'a bytes string'
+    value = 'a string'
     raw = rj.RawJSON(value=value)
-    assert raw.value == b'a bytes string'
+    assert raw.value == value
 
 
 @pytest.mark.unit
 def test_only_bytes_allowed():
     with pytest.raises(TypeError):
-        rj.RawJSON('not a bytes string')
+        rj.RawJSON(b'A bytes string')
     with pytest.raises(TypeError):
         rj.RawJSON({})
     with pytest.raises(TypeError):
@@ -36,4 +36,4 @@ def test_only_bytes_allowed():
 
 
 def test_mix_preserialized():
-    assert rj.dumps({'a': rj.RawJSON(b'{1 : 2}')}) == '{"a":{1 : 2}}'
+    assert rj.dumps({'a': rj.RawJSON('{1 : 2}')}) == '{"a":{1 : 2}}'

--- a/tests/test_refs_count.py
+++ b/tests/test_refs_count.py
@@ -76,6 +76,7 @@ ARRAY_LOAD = {'datetime_mode': rj.DM_ISO8601,
     ( plain_string, NO_OPTION, NO_OPTION ),
     ( bigint, NO_OPTION, NO_OPTION ),
     ( pi, NO_OPTION, NO_OPTION ),
+    ( rj.RawJSON(b' "foo" '), NO_OPTION, NO_OPTION),
     ( right_now, DATETIMES, DATETIMES ),
     ( date, DATETIMES, DATETIMES ),
     ( time, DATETIMES, DATETIMES ),
@@ -138,7 +139,7 @@ def test_decoder_call_leaks():
     assert (rc1 - rc0) < THRESHOLD
 
 
-@pytest.mark.parametrize('value', ['Foo', b'Foo'])
+@pytest.mark.parametrize('value', ['Foo', rj.RawJSON(b'Foo')])
 @pytest.mark.skipif(not hasattr(sys, 'gettotalrefcount'), reason='Non-debug Python')
 def test_encoder_call_leaks(value):
     class MyEncoder(rj.Encoder):

--- a/tests/test_refs_count.py
+++ b/tests/test_refs_count.py
@@ -138,16 +138,20 @@ def test_decoder_call_leaks():
     assert (rc1 - rc0) < THRESHOLD
 
 
+@pytest.mark.parametrize('value', ['Foo', b'Foo'])
 @pytest.mark.skipif(not hasattr(sys, 'gettotalrefcount'), reason='Non-debug Python')
-def test_encoder_call_leaks():
+def test_encoder_call_leaks(value):
     class MyEncoder(rj.Encoder):
+        def __init__(self, value):
+            self.value = value
+
         def default(self, obj):
-            return 'Foo'
+            return self.value
 
     class Foo:
         pass
 
-    encoder = MyEncoder()
+    encoder = MyEncoder(value)
     foo = Foo()
     rc0 = sys.gettotalrefcount()
     for i in range(1000):

--- a/tests/test_refs_count.py
+++ b/tests/test_refs_count.py
@@ -76,7 +76,7 @@ ARRAY_LOAD = {'datetime_mode': rj.DM_ISO8601,
     ( plain_string, NO_OPTION, NO_OPTION ),
     ( bigint, NO_OPTION, NO_OPTION ),
     ( pi, NO_OPTION, NO_OPTION ),
-    ( rj.RawJSON(b' "foo" '), NO_OPTION, NO_OPTION),
+    ( rj.RawJSON(' "foo" '), NO_OPTION, NO_OPTION),
     ( right_now, DATETIMES, DATETIMES ),
     ( date, DATETIMES, DATETIMES ),
     ( time, DATETIMES, DATETIMES ),
@@ -139,7 +139,7 @@ def test_decoder_call_leaks():
     assert (rc1 - rc0) < THRESHOLD
 
 
-@pytest.mark.parametrize('value', ['Foo', rj.RawJSON(b'Foo')])
+@pytest.mark.parametrize('value', ['Foo', rj.RawJSON('Foo')])
 @pytest.mark.skipif(not hasattr(sys, 'gettotalrefcount'), reason='Non-debug Python')
 def test_encoder_call_leaks(value):
     class MyEncoder(rj.Encoder):


### PR DESCRIPTION
For speed reason we're storing some preserialized JSON in our database.

It's still very useful to be able to treat preserialized objects with the same toolchain as the not serialized ones, so we amended python-rapidjson to support our use case.

This PR proposes a change to the `default` function API, so that when it returns a bytes string, it's not further serialized, but instead used verbatim.

Risks:

* existing implementations using `default` and returning a bytes string should no longer expect it to be serialized. We expect all users would return a regular unicode string.
* If client code provides an invalid JSON string, the output of rapidjson will in turn be invalid. This looks acceptable and unavoidable, given the goal is to improve speed