### PR TITLE
Fix for memory leak and doctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@
 #
 # Here we execute the Python 3.6 tests; Python 3.4 and 3.5 tests are run by
 # cibuildwheel, inside the manylinux1 Docker image.
+
+# We also run tests for memory leaks (which require a debug build of python)
+# using python3.4. Specifically we install python3.4-dbg, the only python3
+# runtime with debug support present on the travis-ci platform at the moment.
 #
 # See https://mail.python.org/pipermail/wheel-builders/2017-August/000285.html
 
@@ -21,6 +25,12 @@ matrix:
       python: "3.6"
       services:
         - docker
+    - sudo: required
+      language: python
+      python: "3.4"
+      services:
+        - docker
+      env: RUN_DEBUG_PYTHON=true
     - os: osx
       osx_image: xcode8.3
 
@@ -34,6 +44,12 @@ env:
 
 install:
   - if [ $TRAVIS_OS_NAME = osx ]; then brew upgrade python; fi
+  - |
+    if [ $RUN_DEBUG_PYTHON = true ]; then
+      sudo apt-get install python3.4-dbg
+      virtualenv -p python3.4-dbg /tmp/env
+      . /tmp/env/bin/activate
+    fi
   - pip3 install -r requirements-test.txt
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,11 @@ install:
   - pip3 install -r requirements-test.txt
 
 script:
-  - pip3 install . && pytest tests && cd docs; make doctest; cd -
+  - pip3 install .
+  - pytest tests
+  - pushd docs
+  - make doctest -e PYTHON=$(which python3)
+  - popd
   - |
     pip3 install cibuildwheel==0.6.0
     cibuildwheel --output-dir wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,9 @@ script:
   - pushd docs
   - make doctest -e PYTHON=$(which python3)
   - popd
+  # cibuildwheel's docker might get confused and throw an ImportMismatchError,
+  # so we remove bytecode files before running it.
+  - find . -name __pycache__ -exec rm -rf {} +
   - |
     pip3 install cibuildwheel==0.6.0
     cibuildwheel --output-dir wheelhouse

--- a/docs/dumps.rst
+++ b/docs/dumps.rst
@@ -294,9 +294,9 @@
 
    .. doctest::
 
-      >>> mode = DM_UNIX_TIME
+      >>> mode = DM_UNIX_TIME | DM_NAIVE_IS_UTC
       >>> dumps([now, now.date(), now.time()], datetime_mode=mode)
-      '[1472409071.084418,1472335200.0,73871.084418]'
+      '[1472409071.084418,1472342400.0,73871.084418]'
       >>> unixtime = float(dumps(now, datetime_mode=mode))
       >>> datetime.fromtimestamp(unixtime, here) == now
       True
@@ -306,9 +306,9 @@
 
    .. doctest::
 
-      >>> mode = DM_UNIX_TIME | DM_ONLY_SECONDS
+      >>> mode = DM_UNIX_TIME | DM_NAIVE_IS_UTC | DM_ONLY_SECONDS
       >>> dumps([now, now.date(), now.time()], datetime_mode=mode)
-      '[1472409071,1472335200,73871]'
+      '[1472409071,1472342400,73871]'
 
    It can be used combined with :data:`DM_SHIFT_TO_UTC` to obtain the timestamp of the
    corresponding UTC_ time:

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -434,28 +434,26 @@ RawJSON_dealloc(RawJSON* self)
 }
 
 
-static int
-RawJSON_init(RawJSON* self, PyObject* args, PyObject* kwds)
+static PyObject *
+RawJSON_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
+    PyObject * self;
+    self = type->tp_alloc(type, 0);
     static char * kwlist[] = {
         "value",
         NULL
     };
-    PyObject* value = NULL, *tmp;
+    PyObject* value = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "U", kwlist, &value))
-        return -1;
+        return NULL;
 
-    if (value) {
-        tmp = self->value;
-        Py_INCREF(value);
-        self->value = value;
-        Py_XDECREF(tmp);
-    }
+    ((RawJSON*)self)->value = value;
 
-    return 0;
+    Py_INCREF(value);
+
+    return self;
 }
-
 
 static PyMemberDef RawJSON_members[] = {
     {"value",
@@ -510,9 +508,9 @@ static PyTypeObject RawJSON_Type = {
     0,                              /* tp_descr_get */
     0,                              /* tp_descr_set */
     0,                              /* tp_dictoffset */
-    (initproc) RawJSON_init,        /* tp_init */
+    0,                              /* tp_init */
     0,                              /* tp_alloc */
-    PyType_GenericNew,              /* tp_new */
+    RawJSON_new,                    /* tp_new */
 };
 
 

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -434,12 +434,12 @@ RawJSON_dealloc(RawJSON* self)
 }
 
 
-static PyObject *
-RawJSON_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+static PyObject*
+RawJSON_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 {
-    PyObject * self;
+    PyObject* self;
     self = type->tp_alloc(type, 0);
-    static char * kwlist[] = {
+    static char* kwlist[] = {
         "value",
         NULL
     };
@@ -448,7 +448,7 @@ RawJSON_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "U", kwlist, &value))
         return NULL;
 
-    ((RawJSON*)self)->value = value;
+    ((RawJSON*) self)->value = value;
 
     Py_INCREF(value);
 

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -441,13 +441,17 @@ RawJSON_init(RawJSON* self, PyObject* args, PyObject* kwds)
         "value",
         NULL
     };
-    PyObject* value = NULL;
+    PyObject* value = NULL, *tmp;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "U", kwlist, &value))
         return -1;
 
-    self->value = value;
-    Py_INCREF(self->value);
+    if (value) {
+        tmp = self->value;
+        Py_INCREF(value);
+        self->value = value;
+        Py_XDECREF(tmp);
+    }
 
     return 0;
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest >= 3
 pytz
+sphinx

--- a/tests/test_refs_count.py
+++ b/tests/test_refs_count.py
@@ -172,3 +172,13 @@ def test_rawjson_constructor():
         del value
     rc1 = sys.gettotalrefcount()
     assert (rc1 - rc0) < THRESHOLD
+
+
+@pytest.mark.skipif(not hasattr(sys, 'gettotalrefcount'), reason='Non-debug Python')
+def test_rawjson_new():
+    rc0 = sys.gettotalrefcount()
+    for i in range(1000):
+        raw_json = rj.RawJSON('["foo", "bar"]')
+        del raw_json
+    rc1 = sys.gettotalrefcount()
+    assert (rc1 - rc0) < THRESHOLD

--- a/tests/test_refs_count.py
+++ b/tests/test_refs_count.py
@@ -160,3 +160,15 @@ def test_encoder_call_leaks(value):
         del value
     rc1 = sys.gettotalrefcount()
     assert (rc1 - rc0) < THRESHOLD
+
+
+@pytest.mark.skipif(not hasattr(sys, 'gettotalrefcount'), reason='Non-debug Python')
+def test_rawjson_constructor():
+    raw_json = rj.RawJSON('["foo", "bar"]')
+    rc0 = sys.gettotalrefcount()
+    for i in range(1000):
+        value = '"foobar"'
+        raw_json.__init__(value)
+        del value
+    rc1 = sys.gettotalrefcount()
+    assert (rc1 - rc0) < THRESHOLD


### PR DESCRIPTION
The `__init__` constructor of the `RawJSON` class can be invoked multiple times (silly, but possible).

So the code that takes care of the reference count of the previous `value` probably needs to stay.

I changed the way doctests are run in travis, so that the make the build fail. This uncovered a problem in a doctest: the timezone of the test environment was relevant, so tests were passing on my machine but failing on Travis. I added the `DM_NAIVE_IS_UTC` flag to fix them.

I added tests with the only python-debug version I could find on travis-ci: 3.4.

I'm not sure how these changes interact with the distribution build though.