### PR TITLE
Track rapidjson@67a17cf for bugfixes related to JSONSchema validation

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -45,3 +45,26 @@ def test_invalid(schema, json, details):
     with pytest.raises(ValueError) as error:
         validate(json)
     assert error.value.args == details
+
+
+# See: https://spacetelescope.github.io/understanding-json-schema/reference/object.html#pattern-properties
+@pytest.mark.parametrize('schema', [
+    rj.dumps({
+        "type": "object",
+        "patternProperties": {
+            "^S_": { "type": "string" },
+            "^I_": { "type": "integer" }
+        },
+        "additionalProperties": False
+    }),
+])
+@pytest.mark.parametrize('json', [
+     '{"I_0": 23}',
+     '{"S_1": "the quick brown fox jumps over the lazy dog"}',
+     pytest.param('{"I_2": "A string"}', marks=pytest.mark.xfail),
+     pytest.param('{"keyword": "value"}', marks=pytest.mark.xfail),
+])
+@pytest.mark.unit
+def test_additional_and_pattern_properties_valid(schema, json):
+    validate = rj.Validator(schema)
+    validate(json)


### PR DESCRIPTION
This fixes #102 by updating the rapidjson submodule. This is caused by an issue in the library when processing both additionalProperties and patternProperties in a JSONSchema object. This issue was resolved in a PR.

I've included a test that is based on the examples [here](https://spacetelescope.github.io/understanding-json-schema/reference/object.html#pattern-properties). The provided example in the issue is also verifies that the behavior is fixed.

I've tracked the library to Tencent/rapidjson@67a17cf to reflect a known stable lua binding in mozilla-services/lua_sandbox_extensions#284. However, commits after (or slightly before) this point should also fix the issue.
