### PR TITLE
Fix typo in benchmarks.rst

### DIFF
--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -49,7 +49,7 @@ To reproduce the tables above, run:
 
 .. code-block:: bash
 
-   $ make benchmark-tables
+   $ make benchmarks-tables
 
 
 Compare different versions


### PR DESCRIPTION
There is no benchmark-tables target in the Makefile