### PR TITLE
rename and add mapping modes

### DIFF
--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -187,8 +187,8 @@ enum MappingMode {
     MM_NONE = 0,
     MM_OBJECT = 1<<0,                  // Dump as JSON object
     MM_COERCE_KEYS_TO_STRINGS = 1<<1,  // Convert keys to strings
-    MM_OBJECT_COERCE_KEYS_TO_STRINGS = MM_OBJECT + MM_COERCE_KEYS_TO_STRINGS // Dump as JSON object and convert keys to strings
-    MM_CHECK_STRING_KEYS = 1<<2        // Check for the presence of non-string keys
+    MM_OBJECT_COERCE_KEYS_TO_STRINGS = MM_OBJECT + MM_COERCE_KEYS_TO_STRINGS, // Dump as JSON object and convert keys to strings
+    MM_CHECK_STRING_KEYS = 1<<2,        // Check for the presence of non-string keys
     MM_OBJECT_CHECK_STRING_KEYS = MM_OBJECT + MM_CHECK_STRING_KEYS // Dump as JSON object and check for the presence of non-string keys
 };
 

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -186,8 +186,10 @@ enum IterableMode {
 enum MappingMode {
     MM_NONE = 0,
     MM_OBJECT = 1<<0,                  // Dump as JSON object
-    MM_COERCE_KEYS_TO_STRINGS = 1<<2,  // Convert keys to strings
-    MM_CHECK_STRING_KEYS = 1<<3        // Check for the presence of non-string keys
+    MM_COERCE_KEYS_TO_STRINGS = 1<<1,  // Convert keys to strings
+    MM_OBJECT_COERCE_KEYS_TO_STRINGS = MM_OBJECT + MM_COERCE_KEYS_TO_STRINGS // Dump as JSON object and convert keys to strings
+    MM_CHECK_STRING_KEYS = 1<<2        // Check for the presence of non-string keys
+    MM_OBJECT_CHECK_STRING_KEYS = MM_OBJECT + MM_CHECK_STRING_KEYS // Dump as JSON object and check for the presence of non-string keys
 };
 
 //////////////////////////
@@ -2284,9 +2286,9 @@ dumps_internal(
         }
 
         writer->EndArray();
-    } else if (((mappingMode != MM_NONE && PyDict_Check(object))
+    } else if ((((mappingMode & MM_OBJECT) && PyDict_Check(object))
                 ||
-                (mappingMode == MM_NONE && PyDict_CheckExact(object)))
+                ((!(mappingMode & MM_OBJECT)) && PyDict_CheckExact(object)))
                &&
                (!(mappingMode & MM_CHECK_STRING_KEYS)
                 ||
@@ -2979,7 +2981,7 @@ dumps(PyObject* self, PyObject* args, PyObject* kwargs)
             mappingMode = MM_NONE;
         } else if (PyLong_Check(mappingModeObj)) {
             mappingMode = (MappingMode) PyLong_AsLong(mappingModeObj);
-            if (mappingMode < MM_NONE || mappingMode > MM_CHECK_STRING_KEYS) {
+            if (mappingMode < MM_NONE || mappingMode > MM_CHECK_STRING_KEYS + MM_OBJECT) {
                 PyErr_SetString(PyExc_ValueError, "Invalid mapping_mode");
                 return NULL;
             }
@@ -3245,7 +3247,7 @@ dump(PyObject* self, PyObject* args, PyObject* kwargs)
             mappingMode = MM_NONE;
         } else if (PyLong_Check(mappingModeObj)) {
             mappingMode = (MappingMode) PyLong_AsLong(mappingModeObj);
-            if (mappingMode < MM_NONE || mappingMode > MM_CHECK_STRING_KEYS) {
+            if (mappingMode < MM_NONE || mappingMode > MM_CHECK_STRING_KEYS + MM_OBJECT) {
                 PyErr_SetString(PyExc_ValueError, "Invalid mapping_mode");
                 return NULL;
             }
@@ -3718,7 +3720,7 @@ encoder_new(PyTypeObject* type, PyObject* args, PyObject* kwargs)
             mappingMode = MM_NONE;
         } else if (PyLong_Check(mappingModeObj)) {
             mappingMode = (MappingMode) PyLong_AsLong(mappingModeObj);
-            if (mappingMode < MM_NONE || mappingMode > MM_CHECK_STRING_KEYS) {
+            if (mappingMode < MM_NONE || mappingMode > MM_CHECK_STRING_KEYS + MM_OBJECT) {
                 PyErr_SetString(PyExc_ValueError, "Invalid mapping_mode");
                 return NULL;
             }

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -2708,15 +2708,6 @@ dumps_internal(
         PyObject* retval = PyObject_CallFunctionObjArgs(defaultFn, object, NULL);
         if (retval == NULL)
             return false;
-        if (mappingMode & MM_CHECK_STRING_KEYS
-            &&
-            PyDict_Check(retval)
-            && !all_keys_are_string(retval)) {
-            PyErr_Format(PyExc_ValueError,
-                         "default function result %R contains non-string keys", retval);
-            Py_DECREF(retval);
-            return false;
-        }
         if (Py_EnterRecursiveCall(" while JSONifying default function result")) {
             Py_DECREF(retval);
             return false;
@@ -2981,7 +2972,7 @@ dumps(PyObject* self, PyObject* args, PyObject* kwargs)
             mappingMode = MM_NONE;
         } else if (PyLong_Check(mappingModeObj)) {
             mappingMode = (MappingMode) PyLong_AsLong(mappingModeObj);
-            if (mappingMode < MM_NONE || mappingMode > MM_CHECK_STRING_KEYS + MM_OBJECT) {
+            if (mappingMode < MM_NONE || mappingMode > MM_OBJECT_CHECK_STRING_KEYS) {
                 PyErr_SetString(PyExc_ValueError, "Invalid mapping_mode");
                 return NULL;
             }
@@ -3247,7 +3238,7 @@ dump(PyObject* self, PyObject* args, PyObject* kwargs)
             mappingMode = MM_NONE;
         } else if (PyLong_Check(mappingModeObj)) {
             mappingMode = (MappingMode) PyLong_AsLong(mappingModeObj);
-            if (mappingMode < MM_NONE || mappingMode > MM_CHECK_STRING_KEYS + MM_OBJECT) {
+            if (mappingMode < MM_NONE || mappingMode > MM_OBJECT_CHECK_STRING_KEYS) {
                 PyErr_SetString(PyExc_ValueError, "Invalid mapping_mode");
                 return NULL;
             }
@@ -3720,7 +3711,7 @@ encoder_new(PyTypeObject* type, PyObject* args, PyObject* kwargs)
             mappingMode = MM_NONE;
         } else if (PyLong_Check(mappingModeObj)) {
             mappingMode = (MappingMode) PyLong_AsLong(mappingModeObj);
-            if (mappingMode < MM_NONE || mappingMode > MM_CHECK_STRING_KEYS + MM_OBJECT) {
+            if (mappingMode < MM_NONE || mappingMode > MM_OBJECT_CHECK_STRING_KEYS) {
                 PyErr_SetString(PyExc_ValueError, "Invalid mapping_mode");
                 return NULL;
             }


### PR DESCRIPTION
I order to be able to call default for OrderedDict and dict with no string keys at the same time  , I added MM_OBJECT_COERCE_KEYS_TO_STRINGS and MM_OBJECT_CHECK_STRING_KEYS and made the necessary code changes 