### PR TITLE
Add linux aarch64 wheel build support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
           pytest tests
 
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{matrix.arch}} for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -89,6 +89,11 @@ jobs:
           - ubuntu-20.04
           - macOS-10.15
           - windows-2019
+        arch:
+          - auto
+        include:
+          - os: ubuntu-20.04
+            arch: aarch64
 
     steps:
       - name: Checkout sources
@@ -101,9 +106,14 @@ jobs:
         with:
           python-version: '3.8'
 
+      - uses: docker/setup-qemu-action@v1
+        if:  ${{ matrix.arch == 'aarch64' }}
+        name: Set up QEMU
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v1.11.1
         env:
+          CIBW_ARCHS_LINUX: ${{matrix.arch}}
           CIBW_TEST_REQUIRES: "pytest pytest-benchmark pytz"
           CIBW_TEST_COMMAND: "pytest {project}/tests"
           CIBW_SKIP: "cp2* cp33* cp34* cp35* pp*"


### PR DESCRIPTION
Add linux aarch64 wheel build support.
Related to https://github.com/python-rapidjson/python-rapidjson/issues/155 @lelit Could you please review this PR?