### PR TITLE
Update the test suite to work on Pyston

### DIFF
--- a/tests/test_circular.py
+++ b/tests/test_circular.py
@@ -54,7 +54,15 @@ def test_max_recursion_depth(dumps):
     dumps(root)
 
     rl = sys.getrecursionlimit()
-    sys.setrecursionlimit(500)
+
+    if hasattr(sys, "pyston_version_info"):
+        # In Pyston setrecursionlimit() sets a lower bound on the number of frames,
+        # not an exact count. So set the limit lower:
+        sys.setrecursionlimit(100)
+    else:
+        # Otherwise set it to the exact value:
+        sys.setrecursionlimit(500)
+
     try:
         with pytest.raises(expected_exception):
             dumps(root)

--- a/tests/test_memory_leaks.py
+++ b/tests/test_memory_leaks.py
@@ -9,10 +9,11 @@
 import io
 import datetime
 import gc
-import tracemalloc
 
 import pytest
 import rapidjson as rj
+
+tracemalloc = pytest.importorskip("tracemalloc")
 
 
 def object_hook(td):


### PR DESCRIPTION
The library itself already works, but some of the
debugging features are slightly different in Pyston:
- There is no tracemalloc library
- sys.setrecursionlimit sets a lower bound not an exact count