### PR TITLE
docs: Fix a few typos

### DIFF
--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -51,7 +51,7 @@ static PyObject* validation_error = NULL;
 static PyObject* decode_error = NULL;
 
 
-/* These are the names of oftenly used methods or literal values, interned in the module
+/* These are the names of often used methods or literal values, interned in the module
    initialization function, to avoid repeated creation/destruction of PyUnicode values
    from plain C strings.
 
@@ -393,7 +393,7 @@ public:
             }
         }
         if (c == NULL) {
-            // Propagate the error state, it will be catched by dumps_internal()
+            // Propagate the error state, it will be caught by dumps_internal()
         } else {
             PyObject* res = PyObject_CallMethodObjArgs(stream, write_name, c, NULL);
             if (res == NULL) {

--- a/tests/test_refs_count.py
+++ b/tests/test_refs_count.py
@@ -5,7 +5,7 @@
 # :Copyright: © 2017, 2018, 2020, 2022 Lele Gaifax
 #
 
-# NB: this is a simplicistic test that uses sys.gettotalrefcount(), available
+# NB: this is a simplistic test that uses sys.gettotalrefcount(), available
 # when the interpreter is built --with-pydebug, that tries to assert that
 # repeated calls to dumps() and loads() does not leak object references.
 # Since it's not an exact science, it should be taken with a grain of salt.


### PR DESCRIPTION
There are small typos in:
- rapidjson.cpp
- tests/test_refs_count.py

Fixes:
- Should read `simplistic` rather than `simplicistic`.
- Should read `often` rather than `oftenly`.
- Should read `caught` rather than `catched`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md