### PR TITLE
Use environment variables to use std::regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,3 +123,13 @@ some aspects. See `this section`__ in the documentation for further details.
 __ https://python-rapidjson.readthedocs.io/en/latest/quickstart.html#incompatibilities
 
 .. _RapidJSON: http://rapidjson.org/
+
+Regular Expression
+------------------
+
+By default RapidJson uses a simple NFA regular expression engine for it's schema
+validation, see the section `RapidJson Regular Expression`__, it is possible
+to use ``std::regex`` instead of the original implementation by setting the
+environmental variable ``RAPIDJSON_SCHEMA_USE_STDREGEX``.
+
+__ http://rapidjson.org/md_doc_schema.html#Regex

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@
 
 import os.path
 import sys
+from os import environ
 
 try:
     from setuptools import setup, Extension
@@ -52,12 +53,24 @@ with open('README.rst', encoding='utf-8') as f:
 with open('CHANGES.rst', encoding='utf-8') as f:
     CHANGES = f.read()
 
+if environ.get('RAPIDJSON_SCHEMA_USE_STDREGEX', None):
+    RAPIDJSON_SCHEMA_USE_STDREGEX = 1
+    RAPIDJSON_SCHEMA_USE_INTERNALREGEX = 0
+else:
+    RAPIDJSON_SCHEMA_USE_STDREGEX = 0
+    RAPIDJSON_SCHEMA_USE_INTERNALREGEX = 1
+
 extension_options = {
     'sources': ['./rapidjson.cpp'],
     'include_dirs': [rj_include_dir],
-    'define_macros': [('PYTHON_RAPIDJSON_VERSION', VERSION)],
+    'define_macros': [
+        ('PYTHON_RAPIDJSON_VERSION', VERSION),
+        ('RAPIDJSON_SCHEMA_USE_INTERNALREGEX', RAPIDJSON_SCHEMA_USE_INTERNALREGEX),
+        ('RAPIDJSON_SCHEMA_USE_STDREGEX', RAPIDJSON_SCHEMA_USE_STDREGEX),
+    ],
     'depends': ['./rapidjson_exact_version.txt'],
 }
+
 
 if os.path.exists('rapidjson_exact_version.txt'):
     with open('rapidjson_exact_version.txt', encoding='utf-8') as f:


### PR DESCRIPTION
RapidJson uses an in-house [regex engine ](http://rapidjson.org/md_doc_schema.html#Regex)that has limited syntax, we can use `std::regex` by defining
* RAPIDJSON_SCHEMA_USE_INTERNALREGEX=0
* RAPIDJSON_SCHEMA_USE_STDREGEX=1

This patch extends that functionality to python-rapidjson by using the environmental variable `RAPIDJSON_SCHEMA_USE_STDREGEX`

For example, the following schema uses negative-lookahead (not supported by default engine):

```
{
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "$id": "some_id",
    "type": "object",
    "additionalProperties": False,
    "required": ["metadata"],
    "patternProperties": {
        "^(?!metadata$).+": {
            "type": "string"
        }
    },
    "properties": {
        "metadata": {
            "type": "integer"
        }
    }
}
```

Using this schema leads to a ValidationError using this json `{"a": "a", "metadata": 1}`:

```
>>> import rapidjson   
>>> schema_dict = {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "some_id",
       "type": "object",
       "additionalProperties": False,
       "required": ["metadata"],
       "patternProperties": {
           "^(?!metadata$).+": {
               "type": "string"
           }
       },
       "properties": {
           "metadata": {
               "type": "integer"
           }
       }
   }   
>>> validator = rapidjson.Validator(rapidjson.dumps(schema_dict))
>>> validator(rapidjson.dumps({"a": "a", "metadata": 1}))
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    validator(rapidjson.dumps({"a": "a", "metadata": 1}))
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rapidjson.ValidationError: ('additionalProperties', '#', '#/a')
```

Expected behavior:
```
>>> import rapidjson   
>>> schema_dict = {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "some_id",
       "type": "object",
       "additionalProperties": False,
       "required": ["metadata"],
       "patternProperties": {
           "^(?!metadata$).+": {
               "type": "string"
           }
       },
       "properties": {
           "metadata": {
               "type": "integer"
           }
       }
   }   
>>> validator = rapidjson.Validator(rapidjson.dumps(schema_dict))
>>> validator(rapidjson.dumps({"a": "a", "metadata": 1}))  # no error raised by the validator
```