### PR TITLE
Remark support for JSONC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ JSONC Support
 RapidJSON_ supports decoding JSONC_ using parsing flags. 
 
 .. code-block:: python
+    
     >>> import rapidjson
     >>> rapidjson.Decoder(parse_mode=rapidjson.PM_COMMENTS | rapidjson.PM_TRAILING_COMMAS)('''\
     {
@@ -90,7 +91,7 @@ RapidJSON_ supports decoding JSONC_ using parsing flags.
     ''')
     {'bar': 'baz', 'foo': 100}
 
-    
+
 Development
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ __ https://raw.githubusercontent.com/python-rapidjson/python-rapidjson/master/LI
    :target: https://readthedocs.org/projects/python-rapidjson/builds/
    :alt: Documentation status
 
-RapidJSON_ is an extremely fast C++ JSON parser and serialization library: this module
+RapidJSON_ is an extremely fast C++ JSON and JSONC parser and serialization library: this module
 wraps it into a Python 3 extension, exposing its serialization/deserialization (to/from
 either ``bytes``, ``str`` or *file-like* instances) and `JSON Schema`__ validation
 capabilities.
@@ -76,6 +76,21 @@ Basic usage looks like this:
     Chunk: b'z"}'
 
 
+JSONC Support
+-----------
+RapidJSON_ supports decoding JSONC_ using parsing flags. 
+
+.. code-block:: python
+    >>> import rapidjson
+    >>> rapidjson.Decoder(parse_mode=rapidjson.PM_COMMENTS | rapidjson.PM_TRAILING_COMMAS)('''\
+    {
+        "bar": /* Block comment */ "baz",
+        "foo":100, // Trailing comma and comment
+    }
+    ''')
+    {'bar': 'baz', 'foo': 100}
+
+    
 Development
 -----------
 


### PR DESCRIPTION
This is one of the only JSON parser projects on PyPI that properly supports JSONC, it would be useful to mention it as well as provide an example of how to use the bitwise flags with the library.