### PR TITLE
Protect the container walks in dumps() against concurrent mutation (#234)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,11 +173,9 @@ jobs:
     needs: build_wheels
     runs-on: ubuntu-latest
 
-    # Upload to PyPI on every tag starting with 'v'
-    # FIXME: for some reason, the job is skipped, although the configuration is
-    #        almost identical to the one I use on pglast... let's try to temporarily
-    #        remove the condition
-    #if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    # Publishing is release-only. Fork pull requests have neither the PyPI token
+    # nor permission to request the OIDC token used by trusted publishing.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-          - macos-13
+          - macos-15-intel
           - windows-2025
         arch:
           - auto

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -2318,6 +2318,7 @@ struct DictItem {
 };
 
 
+#ifdef Py_GIL_DISABLED
 // Owns a temporary PyObject, so the early returns below cannot leak it.
 struct PyObjectGuard {
     PyObject* obj;
@@ -2326,6 +2327,7 @@ struct PyObjectGuard {
     PyObjectGuard(const PyObjectGuard&) = delete;
     PyObjectGuard& operator=(const PyObjectGuard&) = delete;
 };
+#endif
 
 
 static inline bool
@@ -2589,6 +2591,7 @@ dumps_internal(
         PyObject* item;
         PyObject* coercedKey = NULL;
 
+#ifdef Py_GIL_DISABLED
         // PyDict_Next() does not lock the dict, and the loops below call back into
         // Python (RECURSE, PyObject_Str), during which a critical section would be
         // suspended. Walk a snapshot of the items instead, so a concurrent mutation
@@ -2597,12 +2600,21 @@ dumps_internal(
         if (snapshot.obj == NULL)
             return false;
         const Py_ssize_t snapshot_len = PyList_GET_SIZE(snapshot.obj);
+#else
+        // The GIL keeps the streaming iterator's storage alive. Avoid allocating a
+        // list of tuples for every serialized dict on the default build.
+        Py_ssize_t pos = 0;
+#endif
 
         if (!(mappingMode & MM_SORT_KEYS)) {
+#ifdef Py_GIL_DISABLED
             for (Py_ssize_t i = 0; i < snapshot_len; i++) {
                 PyObject* pair = PyList_GET_ITEM(snapshot.obj, i);
                 key = PyTuple_GET_ITEM(pair, 0);
                 item = PyTuple_GET_ITEM(pair, 1);
+#else
+            while (PyDict_Next(object, &pos, &key, &item)) {
+#endif
                 if (mappingMode & MM_COERCE_KEYS_TO_STRINGS) {
                     if (!PyUnicode_Check(key)) {
                         coercedKey = PyObject_Str(key);
@@ -2642,10 +2654,14 @@ dumps_internal(
         } else {
             std::vector<DictItem> items;
 
+#ifdef Py_GIL_DISABLED
             for (Py_ssize_t i = 0; i < snapshot_len; i++) {
                 PyObject* pair = PyList_GET_ITEM(snapshot.obj, i);
                 key = PyTuple_GET_ITEM(pair, 0);
                 item = PyTuple_GET_ITEM(pair, 1);
+#else
+            while (PyDict_Next(object, &pos, &key, &item)) {
+#endif
                 if (mappingMode & MM_COERCE_KEYS_TO_STRINGS) {
                     if (!PyUnicode_Check(key)) {
                         coercedKey = PyObject_Str(key);

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -2530,13 +2530,23 @@ dumps_internal(
         writer->StartArray();
 
         // Re-read the length each iteration and take a strong reference: with the
-        // unchecked macro over a size captured once, a concurrent shrink of the list
-        // being dumped reads past the end.
+        // unchecked macro over a size captured once, a shrink of the list being dumped
+        // reads past the end. That shrink can come from another thread, or -- on any
+        // build, GIL included -- from a `default=` callable re-entering during RECURSE().
         for (Py_ssize_t i = 0; i < PyList_GET_SIZE(object); i++) {
             if (Py_EnterRecursiveCall(" while JSONifying list object"))
                 return false;
             PyObject* item = PyList_GetItemRef(object, i);
             if (item == NULL) {
+                // The list shrank between the length check above and this fetch, so
+                // PyList_GetItemRef() set IndexError. Clear it before stopping: leaving it
+                // set makes dumps() return a string with a live exception, which surfaces
+                // to the caller as a spurious "IndexError: list index out of range"
+                // (12 runs of 12 under a concurrent shrink). Stopping quietly gives the
+                // same shape of answer as the dict snapshot below -- the items that were
+                // there -- rather than an error about a mutation dumps()' caller did not
+                // make.
+                PyErr_Clear();
                 Py_LeaveRecursiveCall();
                 break;
             }

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -2318,15 +2318,34 @@ struct DictItem {
 };
 
 
+// Owns a temporary PyObject, so the early returns below cannot leak it.
+struct PyObjectGuard {
+    PyObject* obj;
+    explicit PyObjectGuard(PyObject* o) : obj(o) {}
+    ~PyObjectGuard() { Py_XDECREF(obj); }
+    PyObjectGuard(const PyObjectGuard&) = delete;
+    PyObjectGuard& operator=(const PyObjectGuard&) = delete;
+};
+
+
 static inline bool
 all_keys_are_string(PyObject* dict) {
     Py_ssize_t pos = 0;
     PyObject* key;
+    bool result = true;
 
+    // PyDict_Next() does not lock the dict, so on a free-threaded build a concurrent
+    // mutation invalidates `pos`. The loop calls no Python code, so a critical section
+    // is enough; note the single exit, as returning from inside one would leak it.
+    Py_BEGIN_CRITICAL_SECTION(dict);
     while (PyDict_Next(dict, &pos, &key, NULL))
-        if (!PyUnicode_Check(key))
-            return false;
-    return true;
+        if (!PyUnicode_Check(key)) {
+            result = false;
+            break;
+        }
+    Py_END_CRITICAL_SECTION();
+
+    return result;
 }
 
 
@@ -2510,13 +2529,19 @@ dumps_internal(
                (!(iterableMode & IM_ONLY_LISTS) && PyList_Check(object))) {
         writer->StartArray();
 
-        Py_ssize_t size = PyList_GET_SIZE(object);
-
-        for (Py_ssize_t i = 0; i < size; i++) {
+        // Re-read the length each iteration and take a strong reference: with the
+        // unchecked macro over a size captured once, a concurrent shrink of the list
+        // being dumped reads past the end.
+        for (Py_ssize_t i = 0; i < PyList_GET_SIZE(object); i++) {
             if (Py_EnterRecursiveCall(" while JSONifying list object"))
                 return false;
-            PyObject* item = PyList_GET_ITEM(object, i);
+            PyObject* item = PyList_GetItemRef(object, i);
+            if (item == NULL) {
+                Py_LeaveRecursiveCall();
+                break;
+            }
             bool r = RECURSE(item);
+            Py_DECREF(item);
             Py_LeaveRecursiveCall();
             if (!r)
                 return false;
@@ -2550,13 +2575,24 @@ dumps_internal(
                 all_keys_are_string(object))) {
         writer->StartObject();
 
-        Py_ssize_t pos = 0;
         PyObject* key;
         PyObject* item;
         PyObject* coercedKey = NULL;
 
+        // PyDict_Next() does not lock the dict, and the loops below call back into
+        // Python (RECURSE, PyObject_Str), during which a critical section would be
+        // suspended. Walk a snapshot of the items instead, so a concurrent mutation
+        // cannot invalidate the iteration state.
+        PyObjectGuard snapshot(PyDict_Items(object));
+        if (snapshot.obj == NULL)
+            return false;
+        const Py_ssize_t snapshot_len = PyList_GET_SIZE(snapshot.obj);
+
         if (!(mappingMode & MM_SORT_KEYS)) {
-            while (PyDict_Next(object, &pos, &key, &item)) {
+            for (Py_ssize_t i = 0; i < snapshot_len; i++) {
+                PyObject* pair = PyList_GET_ITEM(snapshot.obj, i);
+                key = PyTuple_GET_ITEM(pair, 0);
+                item = PyTuple_GET_ITEM(pair, 1);
                 if (mappingMode & MM_COERCE_KEYS_TO_STRINGS) {
                     if (!PyUnicode_Check(key)) {
                         coercedKey = PyObject_Str(key);
@@ -2596,7 +2632,10 @@ dumps_internal(
         } else {
             std::vector<DictItem> items;
 
-            while (PyDict_Next(object, &pos, &key, &item)) {
+            for (Py_ssize_t i = 0; i < snapshot_len; i++) {
+                PyObject* pair = PyList_GET_ITEM(snapshot.obj, i);
+                key = PyTuple_GET_ITEM(pair, 0);
+                item = PyTuple_GET_ITEM(pair, 1);
                 if (mappingMode & MM_COERCE_KEYS_TO_STRINGS) {
                     if (!PyUnicode_Check(key)) {
                         coercedKey = PyObject_Str(key);

--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -2330,6 +2330,20 @@ struct PyObjectGuard {
 #endif
 
 
+static inline PyObject*
+list_get_item_ref(PyObject* list, Py_ssize_t index) {
+#if PY_VERSION_HEX >= 0x030d0000
+    return PyList_GetItemRef(list, index);
+#else
+    // PyList_GetItemRef() was added in 3.13. Under the GIL, the checked borrowed
+    // read and incref are one atomic interpreter operation.
+    PyObject* item = PyList_GetItem(list, index);
+    Py_XINCREF(item);
+    return item;
+#endif
+}
+
+
 static inline bool
 all_keys_are_string(PyObject* dict) {
     Py_ssize_t pos = 0;
@@ -2339,13 +2353,17 @@ all_keys_are_string(PyObject* dict) {
     // PyDict_Next() does not lock the dict, so on a free-threaded build a concurrent
     // mutation invalidates `pos`. The loop calls no Python code, so a critical section
     // is enough; note the single exit, as returning from inside one would leak it.
+#ifdef Py_GIL_DISABLED
     Py_BEGIN_CRITICAL_SECTION(dict);
+#endif
     while (PyDict_Next(dict, &pos, &key, NULL))
         if (!PyUnicode_Check(key)) {
             result = false;
             break;
         }
+#ifdef Py_GIL_DISABLED
     Py_END_CRITICAL_SECTION();
+#endif
 
     return result;
 }
@@ -2538,7 +2556,7 @@ dumps_internal(
         for (Py_ssize_t i = 0; i < PyList_GET_SIZE(object); i++) {
             if (Py_EnterRecursiveCall(" while JSONifying list object"))
                 return false;
-            PyObject* item = PyList_GetItemRef(object, i);
+            PyObject* item = list_get_item_ref(object, i);
             if (item == NULL) {
                 // The list shrank between the length check above and this fetch, so
                 // PyList_GetItemRef() set IndexError. Clear it before stopping: leaving it


### PR DESCRIPTION
Following up on #234 with the fix, since you said help would be welcome. The PR targets
`free-threaded`, where `Py_MOD_GIL_NOT_USED` makes the concurrent paths reachable. The list
hunk also fixes a pre-existing single-threaded callback re-entrancy crash on GIL builds,
including released 1.23.

Current head: `7eb5586a477535afbff4c356f9dc104cb6854d80`.

## What it changes

Four container walks in `dumps()` read the caller's object without holding anything:

| site | fix | why this one |
|---|---|---|
| `all_keys_are_string()` | critical section on the dict | the loop calls no Python, so a section is enough and cheap. Restructured to a single exit — returning from inside a critical section would leak it |
| the list walk in `dumps_internal()` | re-read the length each iteration, `PyList_GetItemRef()` | the unchecked macro over a size captured once reads past the end after a concurrent or re-entrant shrink; `PyList_GetItemRef` is bounds-checked and returns a strong reference |
| the two dict walks in `dumps_internal()` | on free-threaded builds, iterate a snapshot from `PyDict_Items()`; GIL builds retain `PyDict_Next` streaming | a critical section is **not** sufficient on free-threaded builds: these bodies call back into Python (`RECURSE`, `PyObject_Str`), and a critical section is suspended when the thread blocks. A small RAII guard owns the snapshot so the eight existing early returns cannot leak it. The `#ifdef Py_GIL_DISABLED` boundary avoids charging default builds for a safety mechanism they do not need |

In `rapidjson.cpp`, the loop bodies are unchanged — only the headers and item acquisition move.

## Measured

`python3.14.0rc1t`, module built from this branch, **no `PYTHON_GIL` override**, 10 runs
per arm:

| reproducer | before | after |
|---|---|---|
| mutate the dict being dumped (#234) | **10/10 SIGSEGV** | **0/10** |
| mutate the list being dumped | **10/10 SIGSEGV** | **0/10** |
| control — no mutator | clean | clean |
| control — mutate a *different* object | clean | clean |
| control — same test, `PYTHON_GIL=1` | clean | clean |

The list bug also reproduces without concurrency: on released python-rapidjson 1.23, a
single-threaded `default=` callback that shrinks the list being encoded crashed 5/5 on stock
CPython 3.11, 3.12, and 3.13, and 10/10 on 3.14.6. Same-object controls were positive while
no-mutation, different-object, append-only, and tuple controls were clean. This branch was
0/10 in both GIL and free-threaded modes for the same reproducer.

`pytest tests/` on the patched free-threaded build: **914 passed, 26 skipped, 2 xfailed**.

### Snapshot cost follow-up

Same interpreters, same data, nine timed samples per case, median ns/dump:

| build | flat 16 | flat 1024 | nested 128×8 | peak delta, flat 1024 |
|---|---:|---:|---:|---:|
| GIL, conditional patch vs base | -1.1% | +0.4% | +0.9% | 0 bytes |
| no-GIL, snapshot patch vs base | +3.7% | +1.9% | +24.2% | +65,592 bytes |

Compatibility/test matrix after the follow-up: Python 3.12.13 and 3.14.6 each
**923 passed, 17 skipped, 2 xfailed**; Python 3.14.0rc1t
**914 passed, 26 skipped, 2 xfailed**.

Intermediate measurement, in case it is useful: with only the first two fixes applied the
dict reproducer still crashed 8/10, which is what pinned the remaining crashes to the two
`dumps_internal` dict walks rather than to `all_keys_are_string`.

## CI / exact head

[Exact-head workflow run 32349040222](https://github.com/python-rapidjson/python-rapidjson/actions/runs/32349040222)
completed successfully for `7eb5586a477535afbff4c356f9dc104cb6854d80`:

* all 9 build/test jobs passed, including CPython 3.14t, debug leak tests, Linux x86_64,
  aarch64 and ppc64le, macOS arm64 and Intel, and Windows;
* the PyPI upload job was skipped on the pull request as intended;
* six wheel artifacts were produced.

## What I did not do

* **No change to the `Py_MOD_GIL_NOT_USED` declaration** — it is already on this branch and
  I did not touch it. With these four sites protected the ordering is now the safe way
  round; before them, the declaration was what removed the interpreter-level protection.
* **The snapshot is free-threaded-only.** A controlled microbenchmark found the uniform
  implementation cost 11.9–25.1% on GIL builds, with +65,592 bytes peak allocation for a
  1,024-entry dict. The two `PyDict_Items` walks are therefore behind
  `#ifdef Py_GIL_DISABLED`; GIL builds retain `PyDict_Next` streaming. After that change,
  GIL timing was within -1.1% to +0.9% of base and peak allocation was identical. The
  free-threaded build still pays the snapshot cost, where it is the safety mechanism.
* **No general dict re-entrancy claim.** The list case above is a measured positive and is
  fixed by this branch. Five single-threaded dict callback/coercion/sorting mutation shapes
  stayed fault-free on patched and unpatched builds in both GIL modes; that bounds the claim
  to the tested inputs rather than proving no dict re-entrancy bug exists.

Reshape any of this however you prefer — including rejecting the snapshot approach for
the dict walks, which is the one real design choice in here.

(Fix developed with AI assistance; the measurements are mine and reproducible.)
