### PR TITLE
Run CI on this branch and on a free-threaded interpreter, and fix the collection error that exposes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,45 @@ name: Build, test and upload to PyPI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, free-threaded ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, free-threaded ]
 
 jobs:
+  free-threaded-tests:
+    name: Tests on the free-threaded interpreter
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.14t']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Without this the job can pass while proving nothing: if the runner ever
+      # falls back to a GIL-enabled interpreter, every test below still passes and
+      # the green tick means "the GIL build works", which is already covered above.
+      - name: Confirm the interpreter really is free-threaded
+        run: |
+          python -c "import sys; assert hasattr(sys, '_is_gil_enabled'), sys.version; assert not sys._is_gil_enabled(), 'GIL is enabled: ' + sys.version; print(sys.version)"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-test.txt
+          pip install .
+
+      - name: Tests
+        run: |
+          pytest tests
+
   tests:
     name: All tests, on current Python
     runs-on: ubuntu-latest

--- a/tests/test_circular.py
+++ b/tests/test_circular.py
@@ -75,7 +75,8 @@ if sys.version_info < (3, 12):
 
 
 @pytest.mark.skipif(
-    not sys._is_gil_enabled(),
+    # sys._is_gil_enabled() exists only on 3.13+; everywhere else the GIL is on.
+    not getattr(sys, "_is_gil_enabled", lambda: True)(),
     reason="Crashes under free-threaded variant, perhaps getrecursionlimit() works differently there?"
 )
 def test_parse_respects_recursion_limit(loads):

--- a/tests/test_memory_leaks.py
+++ b/tests/test_memory_leaks.py
@@ -15,7 +15,8 @@ import pytest
 import rapidjson as rj
 
 pytestmark = pytest.mark.skipif(
-    not sys._is_gil_enabled(),
+    # sys._is_gil_enabled() exists only on 3.13+; everywhere else the GIL is on.
+    not getattr(sys, "_is_gil_enabled", lambda: True)(),
     reason="Crashes under free-threaded variant, perhaps tracemalloc does not work there?"
 )
 tracemalloc = pytest.importorskip("tracemalloc")


### PR DESCRIPTION
Follows up on #235, where you wrote:

> On the CI: yes, I think it should be added, especially because I do not have (yet?) use cases requiring the FT interpreter.

Two commits, and the second one is there because the first one made it visible.

### 1. Run CI on this branch, on a free-threaded interpreter

The workflow triggers on `master` only:

```yaml
on:
  push:
    branches: [ master ]
  pull_request:
    branches: [ master ]
```

so nothing on `free-threaded` — including pull requests into it — has ever been exercised by CI. And no job runs a free-threaded interpreter, so the branch that exists in order to be free-threaded is not tested as one.

This adds `free-threaded` to both filters and one job running the suite on `3.14t`.

The job asserts `sys._is_gil_enabled()` is `False` before installing anything. Without that, the job can go green while proving nothing: if the runner ever resolves `3.14t` to a GIL-enabled interpreter, every test still passes and the tick would mean "the default build works", which the existing job already covers.

Deliberately minimal — build and `pytest` only. Doctests and stubtest are left to the existing job rather than duplicated.

### 2. Guard the free-threading skips so they import on Python < 3.13

Turning CI on immediately produced **three red jobs from one cause**. Both skip conditions call `sys._is_gil_enabled()` at module scope, and that attribute only exists on 3.13+:

```
ERROR collecting tests/test_circular.py
    not sys._is_gil_enabled(),
E   AttributeError: module 'sys' has no attribute '_is_gil_enabled'
```

pytest aborts during collection, so **not a single test runs**. This branch's CI pins 3.11, and `cibuildwheel` runs the suite against every wheel it builds, so the same error took out the test job, the debug job and the macOS wheel job.

`getattr(sys, "_is_gil_enabled", lambda: True)()` keeps the behaviour identical on 3.13+ and treats older interpreters as GIL-enabled, which they are.

### Verified before sending

Both commits were pushed to my fork's `free-threaded` branch so the workflow actually ran, rather than reasoning about it.

**Before the second commit** — [run](https://github.com/espressolee/python-rapidjson/actions/runs/31260844948): the new free-threaded job passed, and `All tests (3.11)`, `Memory leak tests (3.11)` and `Build wheels arm64/macos-14` all **failed** with the collection error above.

**After** — [run](https://github.com/espressolee/python-rapidjson/actions/runs/31261019445): every job that had failed is green.

| job | before | after |
|---|---|---|
| Tests on the free-threaded interpreter (3.14t) | *did not exist* | **success** |
| All tests, on current Python (3.11) | failure | **success** |
| Memory leak tests, debug build (3.11) | failure | **success** |
| Build wheels, arm64 / macos-13 / windows / ubuntu | failure / cancelled | **success** |

At the time of writing, the two QEMU-emulated wheel builds (`aarch64`, `ppc64le`) were still running — they are slow and `CIBW_TEST_SKIP` excludes the suite on emulated hardware, so they do not exercise the change. No job has failed.

### Not in scope

No change to the fix in #235, and no opinion here on the `truncation vs. raise` question still open there.

---

(As on #235: developed with AI assistance. The CI runs linked above are real runs on my fork, and the before/after table is read off them.)
