### PR TITLE
Restore stubtest and release-tag wheel publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ name: Build, test and upload to PyPI
 on:
   push:
     branches: [ master ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ master ]
 
@@ -135,14 +136,11 @@ jobs:
 
   upload_wheels:
     name: Upload wheels to PyPI
-    needs: build_wheels
+    needs: [ tests, debug-tests, build_wheels ]
     runs-on: ubuntu-latest
 
     # Upload to PyPI on every tag starting with 'v'
-    # FIXME: for some reason, the job is skipped, although the configuration is
-    #        almost identical to the one I use on pglast... let's try to temporarily
-    #        remove the condition
-    #if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - uses: actions/download-artifact@v4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,3 +11,4 @@ mypy==2.1.0
 pytest==9.1.1
 pytz==2022.2
 sphinx==8.2.3
+typing-extensions==4.16.0

--- a/typings/rapidjson/__init__.pyi
+++ b/typings/rapidjson/__init__.pyi
@@ -7,6 +7,7 @@
 #
 
 import typing as t
+from typing_extensions import disjoint_base  # type: ignore[attr-defined]
 
 
 __rapidjson_exact_version__: str
@@ -164,19 +165,20 @@ class JSONDecodeError(Exception): ...
 class ValidationError(Exception): ...
 
 
+@disjoint_base
 class Decoder:
     datetime_mode: _DatetimeMode
     number_mode: _NumberMode
     parse_mode: _ParseMode
     uuid_mode: _UUIDMode
 
-    def __init__(
-        self,
+    def __new__(
+        cls,
         datetime_mode: t.Optional[_DatetimeMode] = DM_NONE,
         number_mode: t.Optional[_NumberMode] = NM_NAN,
         parse_mode: t.Optional[_ParseMode] = PM_NONE,
         uuid_mode: t.Optional[_UUIDMode] = UM_NONE,
-    ) -> None: ...
+    ) -> Decoder: ...
     def __call__(
         self,
         json: t.Union[str, bytes, bytearray, t.IO],
@@ -184,6 +186,7 @@ class Decoder:
     ) -> t.Any: ...
 
 
+@disjoint_base
 class Encoder:
     bytes_mode: _BytesMode
     datetime_mode: _DatetimeMode
@@ -198,8 +201,8 @@ class Encoder:
     uuid_mode: _UUIDMode
     write_mode: _WriteMode
 
-    def __init__(
-        self,
+    def __new__(
+        cls,
         skip_invalid_keys: t.Optional[bool] = False,
         ensure_ascii: t.Optional[bool] = True,
         write_mode: t.Optional[_WriteMode] = WM_COMPACT,
@@ -211,7 +214,7 @@ class Encoder:
         bytes_mode: t.Optional[_BytesMode] = BM_UTF8,
         iterable_mode: t.Optional[_IterableMode] = IM_ANY_ITERABLE,
         mapping_mode: t.Optional[_MappingMode] = MM_ANY_MAPPING,
-    ) -> None: ...
+    ) -> Encoder: ...
     def __call__(
         self,
         obj: t.Any,
@@ -223,10 +226,12 @@ class Encoder:
 @t.final
 class RawJSON:
     value: RawJSON
-    def __init__(self, value: str) -> None: ...
+    def __new__(cls, value: str) -> RawJSON: ...
 
 
 @t.final
 class Validator:
-    def __init__(self, json_schema: t.Union[str, bytes, bytearray]) -> None: ...
+    def __new__(
+        cls, json_schema: t.Union[str, bytes, bytearray]
+    ) -> Validator: ...
     def __call__(self, json: t.Union[str, bytes, bytearray]) -> None: ...


### PR DESCRIPTION
## Summary

Restore the two failing parts of the current `master` workflow:

* align the bundled stubs with the C extension types as checked by mypy 2.1;
* run the workflow for `v*` tags and publish wheels only after the test, debug,
  and wheel jobs have succeeded.

Addresses #157.

## Why

The latest exact-`master` workflow, run
[28846305296](https://github.com/python-rapidjson/python-rapidjson/actions/runs/28846305296)
at `00e9a146e958d42f84c81dcfdf39572280ecf01f`, failed in two independent
places:

1. `stubtest rapidjson` reported 19 errors after the test requirements moved to
   mypy 2.1. The C extension constructors are implemented in `tp_new`, while
   the stubs described them as `__init__`; `Decoder` and `Encoder` are also
   runtime disjoint bases.
2. The upload job ran on an ordinary `master` push while the package version
   was still 1.23, so PyPI rejected the first wheel with `400 File already
   exists`.

The old upload condition also used `github.event.ref`, and the workflow only
selected branch pushes, so a release tag could not reach the job even if the
condition were re-enabled.

## Changes

### Typing stubs

* Describe `Decoder`, `Encoder`, `RawJSON`, and `Validator` construction with
  `__new__`, matching their C `tp_new` implementations.
* Mark `Decoder` and `Encoder` with `@disjoint_base`. This preserves valid
  single inheritance while rejecting the same incompatible-layout multiple
  inheritance that fails at runtime.
* Keep the stubs consumable by the branch's older mypy 1.16 through a narrow
  `attr-defined` compatibility ignore on the new typing extension import.

### Release workflow

* Trigger on `v*` tag pushes as well as `master` branch pushes.
* Use `github.ref` for the release-tag predicate.
* Skip publishing on pull requests and ordinary branch pushes.
* Require `tests`, `debug-tests`, and the complete wheel matrix to succeed
  before publishing.

PR #235 contains a related upload guard on the `free-threaded` branch. This
change targets the currently failing `master` release path and additionally
restores the missing tag trigger and validation dependencies.

## Verification

Based on `00e9a146e958d42f84c81dcfdf39572280ecf01f`, candidate head
`e5663ec092e79cbbb4e00937de6d71b3fa35c7c1`:

* mypy 2.1 `stubtest`: 19 baseline errors -> `Success: no issues found`;
* mypy 1.16 `stubtest`: pass;
* type fixtures: `Decoder`/`Encoder` single inheritance accepted; incompatible
  combined inheritance rejected;
* runtime fixture: the same single/multiple-inheritance behavior;
* `pytest -q tests`: 929 passed, 17 skipped, 2 xfailed;
* `actionlint -ignore SC2046`: pass (`SC2046` is the pre-existing
  `$(which python3)` warning);
* workflow truth table: PR and `master` push do not publish; `v1.24` does;
  other branches and non-`v*` tags do not trigger;
* `git diff --check`: pass.

One local macOS/Python 3.13.12 doctest has a pre-existing final-digit float
representation difference. It reproduced identically on unmodified `master`;
the exact Linux workflow above passed all 274 doctests. No documentation or
runtime source is changed here.

No tag or real PyPI publication has been attempted from this branch.

(Developed with AI assistance; the log analysis, runtime checks, and test runs
were executed and verified by me.)
