### PR TITLE
Fix a leak in RawJSON() when the argument is rejected

### DIFF
--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -465,7 +465,6 @@ RawJSON_dealloc(RawJSON* self)
 static PyObject*
 RawJSON_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 {
-    PyObject* self = type->tp_alloc(type, 0);
     static char const* kwlist[] = {
         "value",
         NULL
@@ -473,6 +472,10 @@ RawJSON_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
     PyObject* value = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "U", (char**) kwlist, &value))
+        return NULL;
+
+    PyObject* self = type->tp_alloc(type, 0);
+    if (self == NULL)
         return NULL;
 
     ((RawJSON*) self)->value = value;

--- a/tests/test_memory_leaks.py
+++ b/tests/test_memory_leaks.py
@@ -125,3 +125,30 @@ def test_failed_validation():
     for stat in top_stats[:10]:
         # Uhm, with Py 3.14, on macOS,  the diff is 3...
         assert stat.count_diff <= 3
+
+
+def test_rejected_rawjson_value():
+    tracemalloc.start()
+
+    snapshot1 = tracemalloc.take_snapshot().filter_traces((
+        tracemalloc.Filter(True, __file__),))
+
+    # start the test
+    for j in range(1000):
+        try:
+            rj.RawJSON(j)
+        except TypeError:
+            pass
+
+    del j
+
+    gc.collect()
+
+    snapshot2 = tracemalloc.take_snapshot().filter_traces((
+        tracemalloc.Filter(True, __file__),))
+
+    top_stats = snapshot2.compare_to(snapshot1, 'lineno')
+    tracemalloc.stop()
+
+    for stat in top_stats[:10]:
+        assert stat.count_diff <= 3

--- a/typings/rapidjson/__init__.pyi
+++ b/typings/rapidjson/__init__.pyi
@@ -225,7 +225,7 @@ class Encoder:
 
 @t.final
 class RawJSON:
-    value: RawJSON
+    value: str
     def __new__(cls, value: str) -> RawJSON: ...
 
 


### PR DESCRIPTION
`RawJSON(value)` leaks one object every time the argument is rejected: `RawJSON_new` calls `tp_alloc` before `PyArg_ParseTupleAndKeywords`, and the failure branch returns `NULL` without releasing it. The result of `tp_alloc` was also never checked.

This reorders the constructor to parse first and allocate second, matching `decoder_new` / `encoder_new` / `validator_new`, and adds a tracemalloc test next to the existing ones in `test_memory_leaks.py`. On CPython 3.12.13, 100,000 rejected calls increased `sys.getallocatedblocks()` by 100,001 before this change and by 1 after; the 1.23 source I measured has the same `RawJSON_new` as master.

Also fixes the stub, where `RawJSON.value` was typed as `RawJSON` instead of `str`. That hunk is independent; drop it if you would rather not have it here.

Assisted-by: Claude Code:claude-fable-5-1
